### PR TITLE
Security convergence: port Edge findings into the shared core

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,10 +1,11 @@
-name: Build Extension with Release Metadata
+name: Build Extension Release
 
 on:
   workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*'
 
 permissions:
   contents: write
@@ -14,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: npm
@@ -32,41 +33,25 @@ jobs:
         shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "Invalid Chrome extension release tag: $TAG" >&2
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid extension release tag: $TAG" >&2
             exit 1
           fi
-          VERSION="${TAG#v}"
-          VERSION="$VERSION" node <<'NODE'
+          RELEASE_VERSION="${TAG#v}"
+          MANIFEST_VERSION="${RELEASE_VERSION%%-*}"
+          RELEASE_VERSION="$RELEASE_VERSION" MANIFEST_VERSION="$MANIFEST_VERSION" node <<'NODE'
           const fs = require('node:fs');
           const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
-          manifest.version = process.env.VERSION;
+          manifest.version = process.env.MANIFEST_VERSION;
+          if (process.env.RELEASE_VERSION !== process.env.MANIFEST_VERSION) {
+            manifest.version_name = process.env.RELEASE_VERSION;
+          } else {
+            delete manifest.version_name;
+          }
           fs.writeFileSync('manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
           NODE
 
-      - name: Inject NCBI API identification
-        env:
-          NCBI_TOOL_NAME: ${{ secrets.NCBI_TOOL_NAME_SECRET }}
-          NCBI_API_EMAIL: ${{ secrets.NCBI_API_EMAIL_SECRET }}
-        run: |
-          node <<'NODE'
-          const fs = require('node:fs');
-          const path = 'content/ncbi_api_handler.js';
-          let source = fs.readFileSync(path, 'utf8');
-          const replacements = new Map([
-            ['%%NCBI_TOOL_NAME%%', process.env.NCBI_TOOL_NAME],
-            ['%%NCBI_API_EMAIL%%', process.env.NCBI_API_EMAIL]
-          ]);
-          for (const [placeholder, value] of replacements) {
-            if (!value) throw new Error(`Missing release value for ${placeholder}`);
-            const token = `'${placeholder}'`;
-            if (!source.includes(token)) throw new Error(`Placeholder not found: ${placeholder}`);
-            source = source.replace(token, JSON.stringify(value));
-          }
-          fs.writeFileSync(path, source);
-          NODE
-
-      - name: Run security verification
+      - name: Run security and regression tests
         run: npm test
 
       - name: Build extension
@@ -79,6 +64,7 @@ jobs:
             -x ".git/*" \
             -x ".github/*" \
             -x "scripts/*" \
+            -x "tests/*" \
             -x "package.json" \
             -x "package-lock.json" \
             -x "README.md" \
@@ -90,7 +76,7 @@ jobs:
           unzip -p mdpi-filter.zip manifest.json | node -e "let s=''; process.stdin.on('data',d=>s+=d).on('end',()=>JSON.parse(s));"
 
       - name: Upload extension artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: extension
           path: mdpi-filter.zip
@@ -98,9 +84,8 @@ jobs:
 
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: mdpi-filter.zip
           draft: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: npm
@@ -25,7 +25,7 @@ jobs:
       - name: Install locked dependencies without lifecycle scripts
         run: npm ci --ignore-scripts
 
-      - name: Run security verification
+      - name: Run security and regression tests
         run: npm test
 
       - name: Build extension
@@ -38,6 +38,7 @@ jobs:
             -x ".git/*" \
             -x ".github/*" \
             -x "scripts/*" \
+            -x "tests/*" \
             -x "package.json" \
             -x "package-lock.json" \
             -x "README.md" \
@@ -46,3 +47,4 @@ jobs:
             -x "logo.svg" \
             -x "*.zip"
           unzip -t mdpi-filter.zip
+          unzip -p mdpi-filter.zip manifest.json | node -e "let s=''; process.stdin.on('data',d=>s+=d).on('end',()=>JSON.parse(s));"

--- a/content/inline_footnote_selectors.js
+++ b/content/inline_footnote_selectors.js
@@ -1,175 +1,147 @@
-// Generates CSS selectors for finding inline footnote/citation markers.
-(function() {
-  if (!window.MDPIFilterUtils) {
-    window.MDPIFilterUtils = {};
+'use strict';
+
+(() => {
+  window.MDPIFilterUtils ||= {};
+
+  const FALLBACK_SAFE_REFERENCE_ID = /^[A-Za-z0-9_.:-]{1,256}$/;
+
+  function normalizeReferenceId(value) {
+    const sharedNormalizer = window.MDPIFilterReferenceIdExtractor?.normalizeReferenceId;
+    if (typeof sharedNormalizer === 'function') return sharedNormalizer(value);
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return FALLBACK_SAFE_REFERENCE_ID.test(normalized) ? normalized : null;
   }
 
-  /**
-   * Generates a CSS selector string for finding inline footnotes related to a given reference ID.
-   * @param {string} listItemDomId - The DOM ID of the reference list item (e.g., "B1-journal-id", "ref-CR1", or a data-bib-id if item.id was missing).
-   * @returns {string} - A comma-separated CSS selector string.
-   */
   function generateInlineFootnoteSelectors(listItemDomId) {
-    if (!listItemDomId || typeof listItemDomId !== 'string' || listItemDomId.trim() === "") {
-      return "";
-    }
+    const refId = normalizeReferenceId(listItemDomId);
+    if (!refId) return '';
 
-    // Use listItemDomId as the base refId for generating selectors
-    const refId = listItemDomId;
+    const withoutCiteNote = refId.replace(/^cite_note-/i, '');
+    const withoutRef = refId.replace(/^ref-/i, '');
+    const withoutReference = refId.replace(/^reference-/i, '');
+    const withoutB = refId.replace(/^B/i, '');
+    const withoutCR = refId.replace(/^CR/i, '');
+    const withoutEn = refId.replace(/^en/i, '');
+    const withoutScienceDirectPrefix = refId.replace(/^ref-id-/i, '');
 
     const commonSelectors = [
       `a[href="#${refId}"]`,
-      `a[href$="#${refId}"]`, // Ends with
-      // Handle cases where refId might be "cite_note-B1" and link is "#cite_note-B1" or "B1"
-      `a[href="#cite_note-${refId.replace(/^cite_note-/i, '')}"]`,
-      `a[href="#ref-${refId.replace(/^ref-/i, '')}"]`,                   // Common ref prefix
-      `a[href="#reference-${refId.replace(/^reference-/i, '')}"]`,             // Common reference prefix
-      // Handle cases where refId might be "B1" and link is "#B1" or refId is "1" and link is "#B1"
-      `a[href="#B${refId.replace(/^B/i, '')}"]`,   // NCBI Bxx style
-      `a[href="#CR${refId.replace(/^CR/i, '')}"]`, // Springer style
-      `a[href="#en${refId.replace(/^en/i, '')}"]`, // For ods.od.nih.gov style IDs like "en14"
-      // ADDED FOR TANDFONLINE and similar sites using data-rid or data-bris-rid
+      `a[href$="#${refId}"]`,
+      `a[href="#cite_note-${withoutCiteNote}"]`,
+      `a[href="#ref-${withoutRef}"]`,
+      `a[href="#reference-${withoutReference}"]`,
+      `a[href="#B${withoutB}"]`,
+      `a[href="#CR${withoutCR}"]`,
+      `a[href="#en${withoutEn}"]`,
       `a[data-rid="${refId}"]`,
       `a[data-bris-rid="${refId}"]`,
-      `a[rid="${refId}"]`, // ADDED for EuropePMC and similar sites using plain rid
-      // ADDED FOR NATURE (data-test="citation-ref" and href ending with #ref-CR<ID>)
+      `a[rid="${refId}"]`,
       `a[data-test="citation-ref"][href$="#ref-${refId}"]`,
-      // ADDED FOR CELL.COM and similar sites
-      `a[id="body-ref-${refId}"]`, // Matches <a id="body-ref-sref6"> for listItemDomId "sref6"
-      `a[aria-controls="${refId}"]`,  // Matches <a aria-controls="sref6"> for listItemDomId "sref6"
-      `a[data-db-target-for="${refId}"]`, // ADDED for Cell.com specific attribute
-      // ADDED FOR OXFORD UNIVERSITY PRESS (academic.oup.com)
+      `a[id="body-ref-${refId}"]`,
+      `a[aria-controls="${refId}"]`,
+      `a[data-db-target-for="${refId}"]`,
       `a.link-ref.xref-bibr[reveal-id="${refId}"]`,
       `a.link-ref.xref-bibr[data-open="${refId}"]`,
-      // ADDED for ScienceDirect style IDs like "ref-id-bb0105" or "ref-id-bbb0105"
-      // where inline links might be href="#bb0105" or href="#bbb0105"
-      `a[href="#${refId.replace(/^ref-id-/i, '')}"]`,
-      // --- Added for Sagepub ---
+      `a[href="#${withoutScienceDirectPrefix}"]`,
       `a[role="doc-biblioref"][href="#${refId}"]`,
-      // --- Added for Medicine (LWW) ---
       `a.ejp-citation-link[data-reference-links="${refId}"]`
     ];
 
-    // ScienceDirect specific handling for "ref-id-b..." type IDs
-    // where inline href might be #bb... or #bbb...
-    if (refId.startsWith("ref-id-b")) {
-      const baseSciDirectId = refId.substring("ref-id-".length); // e.g., "bbb0105" or "bb0105"
-      commonSelectors.push(`a[href="#${baseSciDirectId}"]`); // e.g., a[href="#bbb0105"]
-      commonSelectors.push(`a.anchor[href="#${baseSciDirectId}"]`);
-      commonSelectors.push(`a.anchor-primary[href="#${baseSciDirectId}"]`);
-      if (baseSciDirectId.startsWith("b") && baseSciDirectId.length > 1) {
-        const shorterSciDirectId = baseSciDirectId.substring(1); // e.g., "bb0105" from "bbb0105", or "b0105" from "bb0105"
-        commonSelectors.push(`a[href="#${shorterSciDirectId}"]`); // e.g., a[href="#bb0105"]
-        commonSelectors.push(`a.anchor[href="#${shorterSciDirectId}"]`);
-        commonSelectors.push(`a.anchor-primary[href="#${shorterSciDirectId}"]`);
-      }
-    }
-
-
-    const numericRefIdPart = refId.replace(/\D/g, ''); // e.g., "35" from "CR35" or "ref-CR35"
-    if (numericRefIdPart) {
-        commonSelectors.push(`a[href="#${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href$="#${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href="#cite_note-${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href="#ref-${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href="#reference-${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href="#B${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href="#CR${numericRefIdPart}"]`);
-        commonSelectors.push(`a[href="#en${numericRefIdPart}"]`); // For ods.od.nih.gov style IDs with numeric part
-        // Potentially add `a[data-rid="${numericRefIdPart}"]` if some sites use numeric data-rid
-        // ADDED FOR NATURE (data-test="citation-ref" and href ending with #ref-CR<numericID>)
-        commonSelectors.push(`a[data-test="citation-ref"][href$="#ref-CR${numericRefIdPart}"]`);
-    }
-
-    const supParentSelectors = [
+    const supSelectors = [
       `sup a[href="#${refId}"]`,
-      `sup a[href$="#${refId}"]`, // Ends with
-      `sup a[href="#cite_note-${refId.replace(/^cite_note-/i, '')}"]`,
-      `sup a[href="#ref-${refId.replace(/^ref-/i, '')}"]`,
-      `sup a[href="#reference-${refId.replace(/^reference-/i, '')}"]`,
-      `sup a[href="#B${refId.replace(/^B/i, '')}"]`,
-      `sup a[href="#CR${refId.replace(/^CR/i, '')}"]`,
-      `sup a[href="#en${refId.replace(/^en/i, '')}"]`, // For ods.od.nih.gov style IDs like "en14"
-      `sup[id="ref${refId}"]`, // Note: This selector might be too broad if refId is purely numeric.
-                               // Consider if `sup[id="ref-${refId}"]` or similar is more specific.
+      `sup a[href$="#${refId}"]`,
+      `sup a[href="#cite_note-${withoutCiteNote}"]`,
+      `sup a[href="#ref-${withoutRef}"]`,
+      `sup a[href="#reference-${withoutReference}"]`,
+      `sup a[href="#B${withoutB}"]`,
+      `sup a[href="#CR${withoutCR}"]`,
+      `sup a[href="#en${withoutEn}"]`,
+      `sup[id="ref${refId}"]`,
       `sup a[data-rid="${refId}"]`,
       `sup a[data-bris-rid="${refId}"]`,
-      `sup a[rid="${refId}"]`, // ADDED for EuropePMC and similar sites using plain rid
-      // ADDED FOR NATURE (data-test="citation-ref" and href ending with #ref-CR<ID> within a sup)
+      `sup a[rid="${refId}"]`,
       `sup a[data-test="citation-ref"][href$="#ref-${refId}"]`,
-      // ADDED FOR CELL.COM and similar sites (for cases where sup might be the target with these attributes)
       `sup a[id="body-ref-${refId}"]`,
       `sup a[aria-controls="${refId}"]`,
-      `sup a[data-db-target-for="${refId}"]`, // ADDED for Cell.com specific attribute
-      // ADDED FOR OXFORD UNIVERSITY PRESS (academic.oup.com) - if they ever appear in sup
+      `sup a[data-db-target-for="${refId}"]`,
       `sup a.link-ref.xref-bibr[reveal-id="${refId}"]`,
       `sup a.link-ref.xref-bibr[data-open="${refId}"]`,
-     // ADDED for ScienceDirect style IDs
-      `sup a[href="#${refId.replace(/^ref-id-/i, '')}"]`,
-      // --- Added for Sagepub ---
+      `sup a[href="#${withoutScienceDirectPrefix}"]`,
       `sup a[role="doc-biblioref"][href="#${refId}"]`,
-      // --- Added for Medicine (LWW) ---
       `sup a.ejp-citation-link[data-reference-links="${refId}"]`
     ];
 
-    if (refId.startsWith("ref-id-b")) {
-      const baseSciDirectId = refId.substring("ref-id-".length);
-      supParentSelectors.push(`sup a[href="#${baseSciDirectId}"]`);
-      supParentSelectors.push(`sup a.anchor[href="#${baseSciDirectId}"]`);
-      supParentSelectors.push(`sup a.anchor-primary[href="#${baseSciDirectId}"]`);
-      if (baseSciDirectId.startsWith("b") && baseSciDirectId.length > 1) {
-        const shorterSciDirectId = baseSciDirectId.substring(1);
-        supParentSelectors.push(`sup a[href="#${shorterSciDirectId}"]`);
-        supParentSelectors.push(`sup a.anchor[href="#${shorterSciDirectId}"]`);
-        supParentSelectors.push(`sup a.anchor-primary[href="#${shorterSciDirectId}"]`);
+    if (refId.startsWith('ref-id-b')) {
+      const base = refId.slice('ref-id-'.length);
+      commonSelectors.push(
+        `a[href="#${base}"]`,
+        `a.anchor[href="#${base}"]`,
+        `a.anchor-primary[href="#${base}"]`
+      );
+      supSelectors.push(
+        `sup a[href="#${base}"]`,
+        `sup a.anchor[href="#${base}"]`,
+        `sup a.anchor-primary[href="#${base}"]`
+      );
+      if (base.startsWith('b') && base.length > 1) {
+        const shorter = base.slice(1);
+        commonSelectors.push(
+          `a[href="#${shorter}"]`,
+          `a.anchor[href="#${shorter}"]`,
+          `a.anchor-primary[href="#${shorter}"]`
+        );
+        supSelectors.push(
+          `sup a[href="#${shorter}"]`,
+          `sup a.anchor[href="#${shorter}"]`,
+          `sup a.anchor-primary[href="#${shorter}"]`
+        );
       }
     }
 
-     if (numericRefIdPart) {
-        supParentSelectors.push(`sup a[href="#${numericRefIdPart}"]`);
-        supParentSelectors.push(`sup a[href$="#${numericRefIdPart}"]`);
-        supParentSelectors.push(`sup a[href="#cite_note-${numericRefIdPart}"]`);
-        supParentSelectors.push(`sup a[href="#ref-${numericRefIdPart}"]`);
-        supParentSelectors.push(`sup a[href="#reference-${numericRefIdPart}"]`);
-        supParentSelectors.push(`sup a[href="#B${numericRefIdPart}"]`); // Added for consistency
-        supParentSelectors.push(`sup a[href="#CR${numericRefIdPart}"]`); // Added for consistency
-        supParentSelectors.push(`sup a[href="#en${numericRefIdPart}"]`); // For ods.od.nih.gov style IDs with numeric part
-        supParentSelectors.push(`sup[id="ref-${numericRefIdPart}"]`); // More specific for numeric parts
-        // ADDED FOR NATURE (data-test="citation-ref" and href ending with #ref-CR<numericID> within a sup)
-        supParentSelectors.push(`sup a[data-test="citation-ref"][href$="#ref-CR${numericRefIdPart}"]`);
+    const numeric = refId.replace(/\D/g, '');
+    if (numeric) {
+      commonSelectors.push(
+        `a[href="#${numeric}"]`,
+        `a[href$="#${numeric}"]`,
+        `a[href="#cite_note-${numeric}"]`,
+        `a[href="#ref-${numeric}"]`,
+        `a[href="#reference-${numeric}"]`,
+        `a[href="#B${numeric}"]`,
+        `a[href="#CR${numeric}"]`,
+        `a[href="#en${numeric}"]`,
+        `a[data-test="citation-ref"][href$="#ref-CR${numeric}"]`
+      );
+      supSelectors.push(
+        `sup a[href="#${numeric}"]`,
+        `sup a[href$="#${numeric}"]`,
+        `sup a[href="#cite_note-${numeric}"]`,
+        `sup a[href="#ref-${numeric}"]`,
+        `sup a[href="#reference-${numeric}"]`,
+        `sup a[href="#B${numeric}"]`,
+        `sup a[href="#CR${numeric}"]`,
+        `sup a[href="#en${numeric}"]`,
+        `sup[id="ref-${numeric}"]`,
+        `sup a[data-test="citation-ref"][href$="#ref-CR${numeric}"]`
+      );
     }
 
-    // --- Wiley Specific Check Integration ---
-    // If the reference list item was identified by its actual DOM ID (listItemDomId = item.id),
-    // and it also has a 'data-bib-id' attribute, check if inline links use that 'data-bib-id'.
-    // This uses `listItemDomId` which should be the actual ID of the element.
-    const listItemElement = document.getElementById(listItemDomId);
-    if (listItemElement) {
-        const wileyBibId = listItemElement.getAttribute('data-bib-id');
-        if (wileyBibId) {
-            // Escape special characters for CSS selector.
-            const escapedWileyBibId = wileyBibId.replace(/["\\]/g, '\\$&');
-            // Add selectors for this wileyBibId only if it's different from listItemDomId itself,
-            // to avoid redundancy if listItemDomId is already the data-bib-id (because item.id was missing).
-            if (escapedWileyBibId !== listItemDomId) {
-                commonSelectors.push(`a[href="#${escapedWileyBibId}"]`);
-                supParentSelectors.push(`sup a[href="#${escapedWileyBibId}"]`);
-            }
+    const listItem = document.getElementById(refId);
+    const wileyBibId = normalizeReferenceId(listItem?.getAttribute('data-bib-id'));
+    if (wileyBibId && wileyBibId !== refId) {
+      commonSelectors.push(`a[href="#${wileyBibId}"]`);
+      supSelectors.push(`sup a[href="#${wileyBibId}"]`);
+    } else if (!listItem) {
+      for (const candidate of document.querySelectorAll('[data-bib-id]')) {
+        if (candidate.getAttribute('data-bib-id') === refId) {
+          commonSelectors.push(`a[href="#${refId}"]`);
+          supSelectors.push(`sup a[href="#${refId}"]`);
+          break;
         }
-    } else {
-      // --- Wiley fallback: If the selector is a data-bib-id (no id), still add selectors for it ---
-      // This covers the case where the reference <li> has only data-bib-id, and inline <a> uses href="#data-bib-id"
-      // Try to find an element with data-bib-id === listItemDomId
-      const bibIdElement = document.querySelector(`[data-bib-id="${CSS.escape(listItemDomId)}"]`);
-      if (bibIdElement) {
-        // Add selectors for a[href="#<data-bib-id>"] and sup a[href="#<data-bib-id>"]
-        commonSelectors.push(`a[href="#${listItemDomId}"]`);
-        supParentSelectors.push(`sup a[href="#${listItemDomId}"]`);
       }
     }
-    // --- End Wiley Specific Check Integration ---
 
-    return [...new Set([...commonSelectors, ...supParentSelectors])].join(', ');
+    return [...new Set([...commonSelectors, ...supSelectors])].join(', ');
   }
 
   window.MDPIFilterUtils.generateInlineFootnoteSelectors = generateInlineFootnoteSelectors;

--- a/content/ncbi_api_handler.js
+++ b/content/ncbi_api_handler.js
@@ -5,29 +5,42 @@
 
   const ENDPOINT = 'https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/';
   const MDPI_DOI_PREFIX = '10.3390/';
+  const TOOL_NAME = 'mdpi-filter';
   const BATCH_SIZE = 200;
-  const MAX_IDS_PER_RUN = 1000;
-  const REQUEST_TIMEOUT_MS = 15000;
-  const TOOL_NAME = '%%NCBI_TOOL_NAME%%';
-  const MAINTAINER_EMAIL = '%%NCBI_API_EMAIL%%';
+  const MAX_IDS_PER_PAGE = 600;
+  const MAX_CACHE_ENTRIES = 1000;
+  const REQUEST_TIMEOUT_MS = 10000;
+
+  const queriedIdsThisPage = new Set();
+  let remainingLookupBudget = MAX_IDS_PER_PAGE;
 
   function normalizeId(id, idType) {
     if (typeof id !== 'string' && typeof id !== 'number') return null;
-    const value = String(id).trim();
+    let value = String(id).trim();
+    if (!value) return null;
 
     if (idType === 'pmid') {
-      return /^\d{1,20}$/.test(value) ? value : null;
+      return /^\d{1,12}$/.test(value) ? value : null;
     }
     if (idType === 'pmcid') {
-      return /^PMC\d{1,20}$/i.test(value) ? value.toUpperCase() : null;
+      value = value.toUpperCase();
+      return /^PMC\d{1,12}$/.test(value) ? value : null;
     }
     if (idType === 'doi') {
-      const withoutFragment = value.split('#', 1)[0].split('?', 1)[0].trim();
-      return /^10\.\d{4,9}\/[A-Z0-9._;()/:+-]+$/i.test(withoutFragment)
-        ? withoutFragment.toLowerCase()
-        : null;
+      value = value.split('#', 1)[0].split('?', 1)[0].trim().toLowerCase();
+      return /^10\.\d{4,9}\/[^\s"',<>&]{1,240}$/.test(value) ? value : null;
     }
     return null;
+  }
+
+  function normalizeIdsForQuery(ids, idType) {
+    if (!Array.isArray(ids)) return [];
+    const unique = new Set();
+    for (const rawId of ids) {
+      const normalized = normalizeId(rawId, idType);
+      if (normalized) unique.add(normalized);
+    }
+    return Array.from(unique);
   }
 
   function candidateRecordIds(record) {
@@ -50,14 +63,32 @@
     });
   }
 
+  function setBoundedCache(cache, key, value) {
+    if (!(cache instanceof Map)) return;
+    if (cache.has(key)) cache.delete(key);
+    cache.set(key, value);
+    while (cache.size > MAX_CACHE_ENTRIES) {
+      cache.delete(cache.keys().next().value);
+    }
+  }
+
+  function writeResult(id, value, aliases, runCache, ncbiApiCache, persist) {
+    const keys = new Set([id, ...(aliases.get(id) || [])]);
+    for (const key of keys) {
+      runCache.set(key, value);
+      if (persist) setBoundedCache(ncbiApiCache, key, value);
+    }
+  }
+
   function createRequestUrl(batch, idType) {
     const url = new URL(ENDPOINT);
-    url.searchParams.set('ids', batch.join(','));
-    url.searchParams.set('idtype', idType);
-    url.searchParams.set('format', 'json');
-    url.searchParams.set('versions', 'no');
-    if (!TOOL_NAME.startsWith('%%')) url.searchParams.set('tool', TOOL_NAME);
-    if (!MAINTAINER_EMAIL.startsWith('%%')) url.searchParams.set('email', MAINTAINER_EMAIL);
+    url.search = new URLSearchParams({
+      ids: batch.join(','),
+      idtype: idType,
+      format: 'json',
+      versions: 'no',
+      tool: TOOL_NAME
+    }).toString();
     return url.toString();
   }
 
@@ -83,22 +114,13 @@
     }
   }
 
-  function writeResult(id, value, aliases, runCache, ncbiApiCache, persist) {
-    runCache.set(id, value);
-    for (const alias of aliases.get(id) || []) runCache.set(alias, value);
-    if (persist) {
-      ncbiApiCache.set(id, value);
-      for (const alias of aliases.get(id) || []) ncbiApiCache.set(alias, value);
-    }
-  }
-
   async function checkNcbiIdsForMdpi(ids, idType, runCache, ncbiApiCache) {
     if (window.MDPIFilterSettings?.ncbiApiEnabled === false) return false;
     if (!(runCache instanceof Map) || !(ncbiApiCache instanceof Map)) return false;
     if (!['pmid', 'pmcid', 'doi'].includes(idType) || !Array.isArray(ids)) return false;
 
     const aliases = new Map();
-    for (const rawId of ids.slice(0, MAX_IDS_PER_RUN)) {
+    for (const rawId of ids) {
       const normalized = normalizeId(rawId, idType);
       if (!normalized) continue;
       if (!aliases.has(normalized)) aliases.set(normalized, new Set());
@@ -120,8 +142,16 @@
           break;
         }
       }
-      if (found) writeResult(id, cachedValue, aliases, runCache, ncbiApiCache, true);
-      else uncachedIds.push(id);
+
+      if (found) {
+        writeResult(id, cachedValue, aliases, runCache, ncbiApiCache, true);
+      } else if (queriedIdsThisPage.has(id) || remainingLookupBudget <= 0) {
+        writeResult(id, false, aliases, runCache, ncbiApiCache, false);
+      } else {
+        queriedIdsThisPage.add(id);
+        remainingLookupBudget -= 1;
+        uncachedIds.push(id);
+      }
     }
 
     for (let offset = 0; offset < uncachedIds.length; offset += BATCH_SIZE) {
@@ -129,7 +159,6 @@
       const records = await fetchBatch(batch, idType);
 
       if (records === null) {
-        // Do not persist failures; a later page update can retry.
         for (const id of batch) writeResult(id, false, aliases, runCache, ncbiApiCache, false);
         continue;
       }
@@ -150,5 +179,8 @@
     return normalizedIds.some(id => runCache.get(id) === true);
   }
 
-  window.MDPIFilterNcbiApiHandler = { checkNcbiIdsForMdpi };
+  window.MDPIFilterNcbiApiHandler = {
+    checkNcbiIdsForMdpi,
+    normalizeIdsForQuery
+  };
 })();

--- a/content/reference_id_extractor.js
+++ b/content/reference_id_extractor.js
@@ -1,144 +1,63 @@
 (function() {
   'use strict';
 
-  if (window.MDPIFilterReferenceIdExtractor) {
-    return; // Avoid re-injecting the script
+  if (window.MDPIFilterReferenceIdExtractor) return;
+
+  const SAFE_REFERENCE_ID = /^[A-Za-z0-9_.:-]{1,256}$/;
+
+  function normalizeReferenceId(value) {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return SAFE_REFERENCE_ID.test(normalized) ? normalized : null;
   }
 
-  /**
-   * Extracts or generates an internal scroll ID for a reference item.
-   * It also sets the 'data-mdpi-filter-ref-id' attribute on the item.
-   * The returned 'extractedId' is the best guess for an ID that can be used
-   * to link to inline citations.
-   * @param {HTMLElement} itemElement - The DOM element representing the reference item.
-   * @param {number} currentRefIdCounter - The current counter value for generating new IDs.
-   * @returns {{extractedId: string, updatedRefIdCounter: number}} An object containing the extracted/generated ID and the updated counter.
-   */
   function extractInternalScrollId(itemElement, currentRefIdCounter) {
     let idToUse = null;
-    let idSourceForLog = "unknown";
-    let nextRefIdCounter = currentRefIdCounter;
+    let nextRefIdCounter = Number.isInteger(currentRefIdCounter) && currentRefIdCounter >= 0
+      ? currentRefIdCounter
+      : 0;
 
-    // Priority 1: Frontiers-specific anchor name attribute (for <a name="B1" id="B1">)
+    const candidates = [];
     const frontiersAnchor = itemElement.querySelector('a[name][id]');
-    if (frontiersAnchor && frontiersAnchor.name && frontiersAnchor.id) {
-      // Prefer the name attribute as it's more commonly used in inline citations
-      idToUse = frontiersAnchor.name;
-      idSourceForLog = "Frontiers anchor name attribute";
+    if (frontiersAnchor?.name && frontiersAnchor?.id) candidates.push(frontiersAnchor.name);
+
+    const natureElement = itemElement.querySelector('p.c-article-references__text[id^="ref-CR"]');
+    if (natureElement?.id) candidates.push(natureElement.id);
+
+    if (itemElement.dataset?.id) candidates.push(itemElement.dataset.id);
+
+    const scienceDirectAnchor = itemElement.querySelector('span.label a.anchor[id^="ref-id-b"]');
+    if (scienceDirectAnchor?.id) candidates.push(scienceDirectAnchor.id);
+
+    const scienceDirectSpan = itemElement.querySelector('span.reference[id^="rf"]');
+    if (scienceDirectSpan?.id) candidates.push(scienceDirectSpan.id);
+
+    const bmjAnchor = itemElement.querySelector('a.rev-xref-ref[id^="ref-"]');
+    if (bmjAnchor?.id) candidates.push(bmjAnchor.id);
+
+    if (itemElement.id) candidates.push(itemElement.id);
+    candidates.push(
+      itemElement.getAttribute('content-id'),
+      itemElement.getAttribute('data-legacy-id'),
+      itemElement.dataset?.bibId,
+      itemElement.dataset?.mdpiFilterRefId
+    );
+
+    for (const candidate of candidates) {
+      idToUse = normalizeReferenceId(candidate);
+      if (idToUse) break;
     }
 
-    // Priority 2: Nature-specific ID from child <p class="c-article-references__text" id="ref-CR...">
-    if (!idToUse) {
-      const naturePElement = itemElement.querySelector('p.c-article-references__text[id^="ref-CR"]');
-      if (naturePElement && naturePElement.id) {
-        idToUse = naturePElement.id;
-        idSourceForLog = "Nature child p.id";
-      }
-    }
-
-    // Priority 3: Oxford University Press popup reference data-id
-    if (!idToUse && itemElement.dataset && itemElement.dataset.id) {
-      idToUse = itemElement.dataset.id;
-      idSourceForLog = "item.dataset.id (OUP popup)";
-    }
-
-    // Priority 4: ScienceDirect specific ID from child <a id="ref-id-b...">
-    if (!idToUse) {
-      const sciDirectAnchor = itemElement.querySelector('span.label a.anchor[id^="ref-id-b"]');
-      if (sciDirectAnchor && sciDirectAnchor.id) {
-        idToUse = sciDirectAnchor.id;
-        idSourceForLog = "ScienceDirect child a.anchor.id";
-      }
-    }
-
-    // Priority 5: ScienceDirect specific ID from child <span class="reference" id^="rf...">
-    // This is a fallback if the anchor ID isn't found, though less ideal for inline linking.
-    if (!idToUse) {
-      const sciDirectRefSpan = itemElement.querySelector('span.reference[id^="rf"]');
-      if (sciDirectRefSpan && sciDirectRefSpan.id) {
-        idToUse = sciDirectRefSpan.id;
-        idSourceForLog = "ScienceDirect child span.reference.id";
-      }
-    }
-
-    // Priority 5.5 (New): BMJ specific ID from child <a class="rev-xref-ref" id="ref-...">
-    // This anchor's ID is directly targeted by inline citations.
-    if (!idToUse) {
-      const bmjRevXrefAnchor = itemElement.querySelector('a.rev-xref-ref[id^="ref-"]');
-      if (bmjRevXrefAnchor && bmjRevXrefAnchor.id) {
-        idToUse = bmjRevXrefAnchor.id;
-        idSourceForLog = "BMJ child a.rev-xref-ref.id";
-      }
-    }
-
-    // Priority 6: Standard item.id attribute
-    if (!idToUse && itemElement.id) {
-      idToUse = itemElement.id;
-      idSourceForLog = "item.id";
-    }
-
-    // Priority 7: 'content-id' attribute (common in OUP - academic.oup.com)
-    if (!idToUse) {
-      const oupContentId = itemElement.getAttribute('content-id');
-      if (oupContentId) {
-        idToUse = oupContentId;
-        idSourceForLog = "attribute 'content-id'";
-      }
-    }
-    
-    // Priority 8: 'data-legacy-id' attribute (common in OUP)
-    if (!idToUse) {
-      const oupLegacyId = itemElement.getAttribute('data-legacy-id');
-      if (oupLegacyId) {
-        idToUse = oupLegacyId;
-        idSourceForLog = "attribute 'data-legacy-id'";
-      }
-    }
-
-    // Priority 9: 'data-bib-id' attribute (common in Wiley)
-    if (!idToUse && itemElement.dataset && itemElement.dataset.bibId) {
-        idToUse = itemElement.dataset.bibId;
-        idSourceForLog = "item.dataset.bibId";
-    }
-
-    // Priority 10: If no specific linkable ID found yet, check existing 'data-mdpi-filter-ref-id'
-    // This handles cases where the script might re-process an element that already has an ID (possibly generated).
-    if (!idToUse && itemElement.dataset.mdpiFilterRefId) {
-      idToUse = itemElement.dataset.mdpiFilterRefId;
-      idSourceForLog = "existing data-mdpi-filter-ref-id";
-    }
-
-    // If still no ID after all checks, generate a new one.
     if (!idToUse) {
       idToUse = `mdpi-ref-${nextRefIdCounter++}`;
-      itemElement.dataset.mdpiFilterRefId = idToUse; // Set attribute for newly generated
-      idSourceForLog = "generated mdpi-ref-X";
-      console.log(`[MDPI Filter RefIdExtractor] Generated and set data-mdpi-filter-ref-id='${idToUse}' for:`, itemElement);
-    } else {
-      // An ID was found (either specific, existing, or from attributes).
-      // Ensure 'data-mdpi-filter-ref-id' is consistent with this found ID.
-      if (itemElement.dataset.mdpiFilterRefId !== idToUse) {
-        itemElement.dataset.mdpiFilterRefId = idToUse;
-        // Log adoption if the source wasn't "existing..." (which implies it was already the value)
-        // or "generated..." (which has its own log).
-        console.log(`[MDPI Filter RefIdExtractor] Adopted ID from ${idSourceForLog} ('${idToUse}') and set data-mdpi-filter-ref-id for:`, itemElement);
-      } else {
-        // The attribute already matched idToUse.
-        // Log confirmation, unless it was a generated ID (already logged).
-         if (idSourceForLog !== "generated mdpi-ref-X") {
-            console.log(`[MDPI Filter RefIdExtractor] Using ID '${idToUse}' (source: ${idSourceForLog}). data-mdpi-filter-ref-id confirmed. Item:`, itemElement);
-        }
-      }
     }
 
-    return {
-      extractedId: idToUse, // This is the ID to be used by generateInlineFootnoteSelectors
-      updatedRefIdCounter: nextRefIdCounter
-    };
+    itemElement.dataset.mdpiFilterRefId = idToUse;
+    return { extractedId: idToUse, updatedRefIdCounter: nextRefIdCounter };
   }
 
   window.MDPIFilterReferenceIdExtractor = {
-    extractInternalScrollId: extractInternalScrollId
+    extractInternalScrollId,
+    normalizeReferenceId
   };
-
 })();

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -18,15 +18,15 @@ Page content is processed locally. The Extension does not send complete page con
 
 ### Publication identifiers
 
-The Extension may extract Digital Object Identifiers (DOIs), PubMed IDs (PMIDs), and PubMed Central IDs (PMCIDs). Detection results are cached temporarily in memory to avoid repeated work. These caches are not used for tracking and are cleared when the relevant extension or page context ends.
+The Extension may extract Digital Object Identifiers (DOIs), PubMed IDs (PMIDs), and PubMed Central IDs (PMCIDs). Detection results are cached temporarily in memory to avoid repeated work. These caches are bounded, are not used for tracking, and are cleared when the relevant extension or page context ends.
 
 ## 2. External Communications
 
 ### NCBI ID Converter API
 
-When NCBI lookups are enabled, the Extension sends only extracted DOI, PMID, or PMCID values to the NCBI ID Converter endpoint at `https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/`. Requests may include an application name and maintainer contact address, as recommended by NCBI.
+When NCBI lookups are enabled, the Extension sends only validated DOI, PMID, or PMCID values to the NCBI ID Converter endpoint at `https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/`. Requests identify the application as `mdpi-filter`; they do not include a developer email address, browser cookies, or other browser credentials.
 
-Requests use HTTPS, omit browser credentials, and use a no-referrer policy. NCBI will receive the identifiers and the IP address required for normal network communication. NCBI lookups are enabled by default and can be disabled in the Extension’s advanced settings; disabling them may reduce detection accuracy.
+Requests use HTTPS and a no-referrer policy. NCBI receives the identifiers and the IP address required for normal network communication. Lookups are deduplicated, batched, rate-bounded per page, and stored only in bounded in-memory caches. NCBI lookups are enabled by default and can be disabled in the Extension’s advanced settings; disabling them may reduce detection accuracy.
 
 Relevant NCBI and NLM policies:
 
@@ -35,7 +35,7 @@ Relevant NCBI and NLM policies:
 
 ### User-initiated GitHub issue reports
 
-Selecting **Report Filter Issue** opens a public GitHub issue form. The Extension pre-fills the page origin and path, but deliberately removes query parameters and fragments because those may contain search terms, document identifiers, session values, or access tokens. Browser and extension-version information is also pre-filled.
+Selecting **Report Filter Issue** opens a public GitHub issue form. The Extension pre-fills the page origin and path, but deliberately removes query parameters and fragments because those may contain search terms, document identifiers, session values, or access tokens. Browser, extension-version, and current filter-mode information is also pre-filled.
 
 Nothing is submitted automatically. You can review, edit, or discard the report before posting it. Information you submit is handled under GitHub’s privacy terms and may become public.
 
@@ -48,16 +48,18 @@ The Extension contains no advertising or analytics service. We do not sell or re
 - Manifest V3 and a self-only extension Content Security Policy are used.
 - Remote executable code is not loaded.
 - Page-derived reference text is handled as plain text and rendered with `textContent`, not as HTML.
-- Messages crossing extension contexts are validated and bounded.
-- NCBI requests are validated, batched, sent over HTTPS, and made without browser credentials or a referrer.
-- Release dependencies and GitHub Actions are locked and verified during continuous integration.
+- Messages and page-derived identifiers crossing extension contexts are validated and bounded.
+- NCBI requests are validated, deduplicated, batched, time-limited, and made without browser credentials or a referrer.
+- Runtime npm dependencies are not shipped.
+- Release artifacts and GitHub Actions are verified during continuous integration.
 
 No software can be guaranteed completely secure. Security reports should be submitted privately through the repository’s GitHub Security Advisory form.
 
 ## 4. Data Retention
 
 - Preferences remain in `chrome.storage.sync` until changed, cleared, or the Extension is removed.
-- Publication identifiers and detection results are held temporarily in memory.
+- Publication identifiers, reference previews, and detection results are held temporarily in bounded memory caches.
+- Per-tab reference data is cleared when navigation begins or the tab is closed.
 - The Extension does not maintain a persistent browsing-history database.
 - The developer does not receive Extension telemetry.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "__MSG_extDesc__",
   "default_locale": "en",
   "permissions": [
@@ -18,14 +18,14 @@
     "type": "module"
   },
   "icons": {
-    "16":  "icons/icon-16.png",
-    "48":  "icons/icon-48.png",
+    "16": "icons/icon-16.png",
+    "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
   "action": {
     "default_icon": {
-      "16":  "icons/icon-16.png",
-      "48":  "icons/icon-48.png",
+      "16": "icons/icon-16.png",
+      "48": "icons/icon-48.png",
       "128": "icons/icon-128.png"
     },
     "default_title": "MDPI Filter",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdpi-filter-chrome",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdpi-filter-chrome",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "AGPL-3.0-or-later"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "mdpi-filter-chrome",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "Chrome extension that identifies and manages MDPI publications.",
   "scripts": {
     "build": "node scripts/verify-extension.js",
-    "test": "node scripts/verify-extension.js"
+    "test": "node scripts/verify-extension.js && node --test tests/*.test.js"
   },
   "license": "AGPL-3.0-or-later"
 }

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -85,11 +85,11 @@ function verifyHtml(absolutePath) {
 function verifyWorkflow(absolutePath) {
   const relativePath = path.relative(root, absolutePath);
   const source = fs.readFileSync(absolutePath, 'utf8');
-  const actionUses = source.matchAll(/^\s*uses:\s*([^\s]+)\s*$/gm);
+  const actionUses = source.matchAll(/^\s*uses:\s*([^\s#]+)(?:\s*#.*)?\s*$/gm);
   for (const match of actionUses) {
     const reference = match[1];
     if (reference.startsWith('./') || reference.startsWith('docker://')) continue;
-    if (!/@[0-9a-f]{40}(?:\s*#.*)?$/i.test(reference)) {
+    if (!/@[0-9a-f]{40}$/i.test(reference)) {
       fail(`GitHub Action is not pinned to a full commit SHA in ${relativePath}: ${reference}`);
     }
   }

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -6,7 +6,9 @@ const { spawnSync } = require('node:child_process');
 
 const root = path.resolve(__dirname, '..');
 const manifestPath = path.join(root, 'manifest.json');
+const packagePath = path.join(root, 'package.json');
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
 
 function fail(message) {
   console.error(`Security verification failed: ${message}`);
@@ -14,6 +16,12 @@ function fail(message) {
 }
 
 if (manifest.manifest_version !== 3) fail('manifest_version must remain 3');
+if (manifest.version !== packageJson.version) fail('manifest and package versions must match');
+
+const permissions = new Set(manifest.permissions || []);
+for (const permission of permissions) {
+  if (permission !== 'storage') fail(`unexpected privileged permission: ${permission}`);
+}
 
 const extensionCsp = manifest.content_security_policy?.extension_pages || '';
 if (!extensionCsp.includes("script-src 'self'")) fail('extension pages must use a self-only script policy');
@@ -37,12 +45,9 @@ for (const relativePath of referencedFiles) {
   if (!fs.existsSync(path.join(root, relativePath))) fail(`manifest references missing file: ${relativePath}`);
 }
 
-const manifestText = fs.readFileSync(manifestPath, 'utf8');
-if (/dompurify/i.test(manifestText)) {
-  fail('DOMPurify must not be reintroduced without a reviewed HTML sink and pinned upgrade policy');
+if (fs.existsSync(path.join(root, 'content', 'dompurify.min.js'))) {
+  fail('vendored DOMPurify must not be reintroduced into the text-only runtime');
 }
-
-const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 if (packageJson.dependencies && Object.keys(packageJson.dependencies).length > 0) {
   fail('runtime npm dependencies require an explicit security review');
 }
@@ -53,7 +58,8 @@ const dangerousPatterns = [
   { pattern: /document\.write\s*\(/, label: 'document.write()' },
   { pattern: /\.innerHTML\s*=/, label: 'innerHTML assignment' },
   { pattern: /\.outerHTML\s*=/, label: 'outerHTML assignment' },
-  { pattern: /insertAdjacentHTML\s*\(/, label: 'insertAdjacentHTML()' }
+  { pattern: /insertAdjacentHTML\s*\(/, label: 'insertAdjacentHTML()' },
+  { pattern: /%%NCBI_(?:TOOL_NAME|API_EMAIL)%%/, label: 'build-time NCBI secret placeholder' }
 ];
 
 function verifyJavaScript(absolutePath) {
@@ -62,7 +68,6 @@ function verifyJavaScript(absolutePath) {
   if (syntaxCheck.status !== 0) {
     fail(`JavaScript syntax error in ${relativePath}: ${syntaxCheck.stderr.trim()}`);
   }
-
   if (absolutePath === __filename) return;
   const source = fs.readFileSync(absolutePath, 'utf8');
   for (const { pattern, label } of dangerousPatterns) {
@@ -77,6 +82,22 @@ function verifyHtml(absolutePath) {
   if (/<script\b(?![^>]*\bsrc\s*=)[^>]*>[\s\S]*?<\/script>/i.test(source)) fail(`inline script found in ${relativePath}`);
 }
 
+function verifyWorkflow(absolutePath) {
+  const relativePath = path.relative(root, absolutePath);
+  const source = fs.readFileSync(absolutePath, 'utf8');
+  const actionUses = source.matchAll(/^\s*uses:\s*([^\s]+)\s*$/gm);
+  for (const match of actionUses) {
+    const reference = match[1];
+    if (reference.startsWith('./') || reference.startsWith('docker://')) continue;
+    if (!/@[0-9a-f]{40}(?:\s*#.*)?$/i.test(reference)) {
+      fail(`GitHub Action is not pinned to a full commit SHA in ${relativePath}: ${reference}`);
+    }
+  }
+  if (/NCBI_(?:TOOL_NAME|API_EMAIL)_SECRET/.test(source)) {
+    fail(`release workflow embeds unnecessary NCBI secrets in ${relativePath}`);
+  }
+}
+
 function walk(directory) {
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     if (entry.name === '.git' || entry.name === 'node_modules' || entry.name === 'docs') continue;
@@ -84,6 +105,9 @@ function walk(directory) {
     if (entry.isDirectory()) walk(absolutePath);
     else if (entry.name.endsWith('.js')) verifyJavaScript(absolutePath);
     else if (entry.name.endsWith('.html')) verifyHtml(absolutePath);
+    else if (/\.ya?ml$/i.test(entry.name) && absolutePath.includes(`${path.sep}.github${path.sep}workflows${path.sep}`)) {
+      verifyWorkflow(absolutePath);
+    }
   }
 }
 

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function loadScript(relativePath, additions = {}) {
+  const context = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout,
+    clearTimeout,
+    URL,
+    URLSearchParams,
+    AbortController,
+    Map,
+    Set,
+    ...additions
+  };
+  context.window ||= {};
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, relativePath), 'utf8'), context, {
+    filename: relativePath
+  });
+  return context;
+}
+
+test('reference identifiers reject selector metacharacters and excessive length', () => {
+  const context = loadScript('content/reference_id_extractor.js');
+  const normalize = context.window.MDPIFilterReferenceIdExtractor.normalizeReferenceId;
+
+  assert.equal(normalize('ref-CR12'), 'ref-CR12');
+  assert.equal(normalize('  B1:section.2  '), 'B1:section.2');
+  assert.equal(normalize('bad"] * { display:none }'), null);
+  assert.equal(normalize('x'.repeat(257)), null);
+});
+
+test('inline selector construction rejects unsafe page identifiers', () => {
+  const window = {
+    MDPIFilterReferenceIdExtractor: {
+      normalizeReferenceId(value) {
+        if (typeof value !== 'string') return null;
+        const normalized = value.trim();
+        return /^[A-Za-z0-9_.:-]{1,256}$/.test(normalized) ? normalized : null;
+      }
+    }
+  };
+  const document = {
+    getElementById() { return null; },
+    querySelectorAll() { return []; }
+  };
+  loadScript('content/inline_footnote_selectors.js', { window, document });
+
+  const generate = window.MDPIFilterUtils.generateInlineFootnoteSelectors;
+  assert.match(generate('CR12'), /href="#CR12"/);
+  assert.equal(generate('x"] div'), '');
+});
+
+test('sanitizer preserves only plain string values', () => {
+  const window = {};
+  loadScript('content/sanitizer.js', { window });
+  assert.equal(window.sanitize('<b>Reference</b>'), '<b>Reference</b>');
+  assert.equal(window.sanitize({ text: 'Reference' }), '');
+});
+
+test('NCBI lookups validate, deduplicate, omit credentials, and enforce page budget', async () => {
+  const requests = [];
+  const fetch = async (url, options) => {
+    requests.push({ url: String(url), options });
+    return {
+      ok: true,
+      headers: { get: () => 'application/json; charset=utf-8' },
+      async json() { return { records: [] }; }
+    };
+  };
+
+  const window = { MDPIFilterSettings: { ncbiApiEnabled: true } };
+  loadScript('content/ncbi_api_handler.js', { window, fetch });
+  const handler = window.MDPIFilterNcbiApiHandler;
+  const runCache = new Map();
+  const persistentCache = new Map();
+
+  assert.deepEqual(
+    Array.from(handler.normalizeIdsForQuery(['123', '123', 'bad', '456'], 'pmid')),
+    ['123', '456']
+  );
+  assert.deepEqual(
+    Array.from(handler.normalizeIdsForQuery(['10.1000/OK', '10.1000/bad,split'], 'doi')),
+    ['10.1000/ok']
+  );
+
+  await handler.checkNcbiIdsForMdpi(
+    Array.from({ length: 800 }, (_, index) => String(index + 1)),
+    'pmid',
+    runCache,
+    persistentCache
+  );
+
+  assert.equal(requests.length, 3);
+  const queriedIds = requests.flatMap(request => new URL(request.url).searchParams.get('ids').split(','));
+  assert.equal(queriedIds.length, 600);
+  assert.equal(new Set(queriedIds).size, 600);
+  for (const request of requests) {
+    const parsed = new URL(request.url);
+    assert.equal(parsed.searchParams.get('tool'), 'mdpi-filter');
+    assert.equal(parsed.searchParams.has('email'), false);
+    assert.equal(request.options.credentials, 'omit');
+    assert.equal(request.options.referrerPolicy, 'no-referrer');
+  }
+
+  await handler.checkNcbiIdsForMdpi(['901', '902'], 'pmid', runCache, persistentCache);
+  assert.equal(requests.length, 3);
+});
+
+test('manifest and package maintain the converged least-privilege contract', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+
+  assert.equal(manifest.manifest_version, 3);
+  assert.deepEqual(manifest.permissions, ['storage']);
+  assert.equal(manifest.version, packageJson.version);
+  assert.equal(fs.existsSync(path.join(ROOT, 'content', 'dompurify.min.js')), false);
+  assert.equal(Object.keys(packageJson.dependencies || {}).length, 0);
+  assert.ok(manifest.content_scripts[0].js.includes('content/secure_message_handler.js'));
+});
+
+test('workflows pin actions and do not embed NCBI secrets', () => {
+  const workflowDirectory = path.join(ROOT, '.github', 'workflows');
+  for (const filename of fs.readdirSync(workflowDirectory).filter(name => /\.ya?ml$/i.test(name))) {
+    const workflow = fs.readFileSync(path.join(workflowDirectory, filename), 'utf8');
+    for (const match of workflow.matchAll(/^\s*uses:\s*([^\s#]+)/gm)) {
+      assert.match(match[1], /@[0-9a-f]{40}$/i, `${filename}: ${match[1]}`);
+    }
+    assert.doesNotMatch(workflow, /NCBI_(?:TOOL_NAME|API_EMAIL)_SECRET/);
+  }
+});


### PR DESCRIPTION
## Purpose

Converge the Chrome and Microsoft Edge editions on one security/runtime baseline while preserving only store-specific metadata.

## Improvements imported from the Edge security review

- Validate page-derived reference IDs before any CSS selector construction.
- Generate extension-owned IDs when page identifiers are unsafe.
- Bound NCBI activity to 600 unique identifiers per page, 200 per request, and 1,000 cache entries.
- Prevent repeated lookups and preserve raw/normalized cache-key compatibility.
- Remove NCBI build secrets and use a shared, non-identifying `tool=mdpi-filter` value.
- Support validated prerelease tags using `version_name`.
- Upgrade and pin the GitHub Actions release toolchain.

## Shared cross-browser contract

- Version 0.0.4.
- Manifest V3.
- Only the `storage` extension permission plus the required HTTPS host access.
- No runtime npm dependencies and no vendored HTML sanitizer.
- Page-derived previews are plain text only.
- Identical NCBI request validation, limits, timeouts, credentials/referrer policy, and cache behavior.
- Identical security verification and regression tests.
- Identical build/release workflow logic.

## Verification added

The shared test suite covers identifier normalization, selector construction, NCBI deduplication and page budgets, no-referrer/no-credentials requests, least-privilege manifests, dependency-free packaging, and immutable GitHub Action pins.

## Intended differences from Edge

Only package/repository identity, homepage/store references, and browser-specific privacy-policy wording should differ.