### PR TITLE
Build and publish browser-specific releases from one repository

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,4 +1,4 @@
-name: Build Extension Release
+name: Build Multi-Browser Release
 
 on:
   workflow_dispatch:
@@ -8,10 +8,10 @@ on:
       - 'v*.*.*-*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,64 +28,123 @@ jobs:
       - name: Install locked dependencies without lifecycle scripts
         run: npm ci --ignore-scripts
 
-      - name: Validate and apply tag version
-        if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid extension release tag: $TAG" >&2
-            exit 1
-          fi
-          RELEASE_VERSION="${TAG#v}"
-          MANIFEST_VERSION="${RELEASE_VERSION%%-*}"
-          RELEASE_VERSION="$RELEASE_VERSION" MANIFEST_VERSION="$MANIFEST_VERSION" node <<'NODE'
-          const fs = require('node:fs');
-          const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
-          manifest.version = process.env.MANIFEST_VERSION;
-          if (process.env.RELEASE_VERSION !== process.env.MANIFEST_VERSION) {
-            manifest.version_name = process.env.RELEASE_VERSION;
-          } else {
-            delete manifest.version_name;
-          }
-          fs.writeFileSync('manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
-          NODE
-
       - name: Run security and regression tests
         run: npm test
 
-      - name: Build extension
-        run: npm run build
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - chrome
+          - edge
+          - firefox
+          - safari
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Create and verify ZIP package
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install locked dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Resolve release version
+        id: version
+        shell: bash
         run: |
-          zip -r mdpi-filter.zip . \
-            -x "node_modules/*" \
-            -x ".git/*" \
-            -x ".github/*" \
-            -x "scripts/*" \
-            -x "tests/*" \
-            -x "package.json" \
-            -x "package-lock.json" \
-            -x "README.md" \
-            -x "SECURITY.md" \
-            -x "docs/*" \
-            -x "logo.svg" \
-            -x "*.zip"
-          unzip -t mdpi-filter.zip
-          unzip -p mdpi-filter.zip manifest.json | node -e "let s=''; process.stdin.on('data',d=>s+=d).on('end',()=>JSON.parse(s));"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="$GITHUB_REF_NAME"
+            if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){0,3}(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid extension release tag: $TAG" >&2
+              exit 1
+            fi
+            VERSION="${TAG#v}"
+          else
+            VERSION="$(node -p "require('./package.json').version")"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Upload extension artifact
+      - name: Build target package
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: node scripts/build-target.js --target "$TARGET" --version "$VERSION"
+
+      - name: Create reproducible ZIP
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          case "$TARGET" in
+            chrome|edge)
+              FILENAME="mdpi-filter-${TARGET}-v${VERSION}.zip"
+              ;;
+            firefox|safari)
+              FILENAME="mdpi-filter-${TARGET}-source-v${VERSION}.zip"
+              ;;
+            *)
+              echo "Unsupported target: $TARGET" >&2
+              exit 1
+              ;;
+          esac
+
+          mkdir -p release-assets
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          find "dist/$TARGET" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+          (
+            cd "dist/$TARGET"
+            find . -type f -print | LC_ALL=C sort | zip -X -q "../../release-assets/$FILENAME" -@
+          )
+          unzip -tq "release-assets/$FILENAME"
+          unzip -p "release-assets/$FILENAME" manifest.json \
+            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>JSON.parse(s));"
+
+      - name: Upload target artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: extension
-          path: mdpi-filter.zip
+          name: browser-${{ matrix.target }}
+          path: release-assets/*.zip
           if-no-files-found: error
+          compression-level: 0
 
-      - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download verified target artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --dir downloaded
+
+      - name: Create release checksum inventory
+        shell: bash
+        run: |
+          mkdir -p release-assets
+          find downloaded -type f -name '*.zip' -exec cp {} release-assets/ \;
+          test "$(find release-assets -maxdepth 1 -type f -name '*.zip' | wc -l)" -eq 4
+          (
+            cd release-assets
+            sha256sum *.zip | LC_ALL=C sort -k2 > checksums.txt
+          )
+
+      - name: Create immutable release candidate
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
-          files: mdpi-filter.zip
+          files: release-assets/*
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -141,7 +141,7 @@ jobs:
             sha256sum *.zip | LC_ALL=C sort -k2 > checksums.txt
           )
 
-      - name: Create immutable release candidate
+      - name: Create GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: release-assets/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Extension
+name: Build Browser Extensions
 
 on:
   push:
@@ -28,23 +28,15 @@ jobs:
       - name: Run security and regression tests
         run: npm test
 
-      - name: Build extension
+      - name: Build all browser targets
         run: npm run build
 
-      - name: Create and verify ZIP package
+      - name: Verify generated manifests and runtime files
+        shell: bash
         run: |
-          zip -r mdpi-filter.zip . \
-            -x "node_modules/*" \
-            -x ".git/*" \
-            -x ".github/*" \
-            -x "scripts/*" \
-            -x "tests/*" \
-            -x "package.json" \
-            -x "package-lock.json" \
-            -x "README.md" \
-            -x "SECURITY.md" \
-            -x "docs/*" \
-            -x "logo.svg" \
-            -x "*.zip"
-          unzip -t mdpi-filter.zip
-          unzip -p mdpi-filter.zip manifest.json | node -e "let s=''; process.stdin.on('data',d=>s+=d).on('end',()=>JSON.parse(s));"
+          for target in chrome edge firefox safari; do
+            test -f "dist/$target/manifest.json"
+            test -f "dist/$target/background.js"
+            test -f "dist/$target/content/content_script.js"
+            node -e "JSON.parse(require('fs').readFileSync('dist/$target/manifest.json', 'utf8'))"
+          done

--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -129,11 +129,10 @@ jobs:
           rm -rf firefox-source
           mkdir firefox-source
           unzip -q "$PACKAGE" -d firefox-source
-          npm exec --yes --package=web-ext@10.5.0 -- web-ext sign \
+          npm exec --yes --package=web-ext@10.5.0 -- web-ext --no-input sign \
             --source-dir firefox-source \
             --channel listed \
             --amo-metadata store/firefox/amo-metadata.json \
             --api-key "$AMO_JWT_ISSUER" \
             --api-secret "$AMO_JWT_SECRET" \
-            --approval-timeout 0 \
-            --no-input
+            --approval-timeout 0

--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -1,0 +1,139 @@
+name: Publish Browser Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      store:
+        description: Store receiving the verified release artifact
+        required: true
+        type: choice
+        options:
+          - chrome
+          - edge
+          - firefox
+      tag:
+        description: Existing GitHub release tag, for example v0.1.0
+        required: true
+        type: string
+      submit:
+        description: Submit the uploaded package for review/publication
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ inputs.store }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: store-${{ inputs.store }}
+    steps:
+      - name: Validate requested tag
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){0,3}(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
+
+      - name: Checkout the released source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir release-assets
+
+      - name: Verify release checksums
+        shell: bash
+        run: |
+          test -f release-assets/checksums.txt
+          (
+            cd release-assets
+            sha256sum -c checksums.txt --ignore-missing
+          )
+
+      - name: Resolve store package
+        id: package
+        shell: bash
+        env:
+          STORE: ${{ inputs.store }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          case "$STORE" in
+            chrome|edge)
+              PACKAGE="release-assets/mdpi-filter-${STORE}-v${VERSION}.zip"
+              ;;
+            firefox)
+              PACKAGE="release-assets/mdpi-filter-firefox-source-v${VERSION}.zip"
+              ;;
+            *)
+              echo "Unsupported store: $STORE" >&2
+              exit 1
+              ;;
+          esac
+          test -f "$PACKAGE"
+          echo "path=$PACKAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload or publish Chrome package
+        if: inputs.store == 'chrome'
+        env:
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          SUBMIT: ${{ inputs.submit }}
+        run: node scripts/publish-chrome.js "${{ steps.package.outputs.path }}"
+
+      - name: Upload or publish Edge package
+        if: inputs.store == 'edge'
+        env:
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+          EDGE_CERTIFICATION_NOTES: ${{ vars.EDGE_CERTIFICATION_NOTES }}
+          SUBMIT: ${{ inputs.submit }}
+        run: node scripts/publish-edge.js "${{ steps.package.outputs.path }}"
+
+      - name: Submit Firefox package to AMO
+        if: inputs.store == 'firefox'
+        shell: bash
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+          PACKAGE: ${{ steps.package.outputs.path }}
+          SUBMIT: ${{ inputs.submit }}
+        run: |
+          if [[ "$SUBMIT" != "true" ]]; then
+            echo "AMO does not expose a useful draft-only mode through web-ext; rerun with submit enabled after reviewing the release." >&2
+            exit 1
+          fi
+          rm -rf firefox-source
+          mkdir firefox-source
+          unzip -q "$PACKAGE" -d firefox-source
+          npm exec --yes --package=web-ext@10.5.0 -- web-ext sign \
+            --source-dir firefox-source \
+            --channel listed \
+            --amo-metadata store/firefox/amo-metadata.json \
+            --api-key "$AMO_JWT_ISSUER" \
+            --api-secret "$AMO_JWT_SECRET" \
+            --approval-timeout 0 \
+            --no-input

--- a/README.md
+++ b/README.md
@@ -1,188 +1,125 @@
-# mdpi-filter-chrome
+# MDPI Filter browser extension
 
-**MDPI Filter** is a Chrome extension that helps you identify and manage MDPI publications. It enhances your literature search by allowing you to hide or highlight MDPI results on major search engines (Google, Google Scholar, PubMed, Europe PMC), using direct checks and the NCBI API. Furthermore, it universally styles MDPI citations on any scholarly article you read: visually distinguishing MDPI entries in bibliographies, their inline footnotes, and also within "Cited By" and "Similar Articles" sections. The extension popup provides a quick overview of detected MDPI references, allowing you to see a count, a list, and click to scroll to them in the document.
+**MDPI Filter** identifies MDPI publications in literature searches and scholarly references. This repository is the canonical browser-extension source for Chrome, Microsoft Edge, Firefox, and Safari.
 
----
+## Browser outputs
 
-## 🔹 Features
+| Target | Generated release asset | Distribution status |
+|---|---|---|
+| Chrome | `mdpi-filter-chrome-vX.Y.Z.zip` | Uploadable to Chrome Web Store |
+| Microsoft Edge | `mdpi-filter-edge-vX.Y.Z.zip` | Uploadable to Microsoft Edge Add-ons |
+| Firefox | `mdpi-filter-firefox-source-vX.Y.Z.zip` | Submitted to AMO for Mozilla signing |
+| Safari | `mdpi-filter-safari-source-vX.Y.Z.zip` | Local compatibility source; App Store publication deferred |
 
-- **Search-site filtering**  
-  - **Hide** or **Highlight** MDPI links on:
-    - Google Web Search
-    - Google Scholar
-    - PubMed
-    - Europe PMC
-- **Universal in-page citation styling**  
-  - **Inline footnotes**: turns MDPI reference numbers red wherever they appear.
-  - **Reference lists**: outlines and bold-reds MDPI entries in bibliographies across *any* journal site.
-- **Popup Interaction & Overview**
-  - **Counts MDPI References**: Displays the total number of MDPI references found on the current page.
-  - **Lists MDPI References**: Shows a clickable list of identified MDPI references.
-  - **Scroll-to-Reference**: Allows you to click on a reference in the popup to scroll directly to its location in the document.
-  - **"Cited By" sections**: styles MDPI entries within lists of citing articles.
-  - **"Similar Articles" sections**: styles MDPI entries within lists of similar articles.
----
+All packages are generated from the same source commit. Browser-specific manifests, store metadata, terminology restrictions, and credentials remain isolated.
 
-## 📥 Installation
+## Features
 
-1.  **Download the Extension:**
-    *   Go to the [**Releases**](https://github.com/mdpi-filter/mdpi-filter-chrome/releases) page of this repository.
-    *   Download the `mdpi-filter-extension.zip` file from the latest release.
-    *   Unzip the downloaded file. This will create a folder containing the extension files.
+- Hide or highlight MDPI results on Google, Google Scholar, PubMed, and Europe PMC.
+- Mark MDPI entries in reference lists.
+- Mark related inline numerical citations where page structure permits.
+- Identify MDPI entries in cited-by and similar-article sections.
+- Show detected references in the toolbar popup and scroll to a selected reference.
+- Resolve PMID and PMCID identifiers through NCBI when direct DOI evidence is unavailable.
+- Disable all optional network detection through the extension preference.
 
-2.  **Install in Chrome:**
-    *   Open Chrome and navigate to `chrome://extensions`.
-    *   Enable **Developer mode** (usually a toggle in the top right corner).
-    *   Click the **Load unpacked** button.
-    *   Select the unzipped folder (e.g., `mdpi-filter-extension`) that you extracted.
+## Development
 
-3.  **Pin the Icon:**
-    *   The MDPI Filter extension should now be installed. Pin its icon to your toolbar for easy access.
+Requirements:
 
-**For Developers:** If you've cloned the repository and want to load the source code directly for development, you can use the "Load unpacked" button to select the `mdpi-filter-chrome/` root folder. Note that for full NCBI API functionality, you would need to manually add your API credentials to `content/ncbi_api_handler.js` if you are not using a pre-built release version.
+- Node.js 24
+- npm
+- `zip` for creating release archives locally
 
----
+Run the complete verification and build:
 
-## 📦 Building and Releases
-
-This extension is automatically built and packaged using GitHub Actions whenever a new tag (e.g., `vX.Y.Z` or `vX.Y.Z-prerelease`) is pushed to the repository.
-
-The build process includes:
-1.  Checking out the source code.
-2.  Injecting necessary API credentials (NCBI API Email and Tool Name) from GitHub secrets into the `content/ncbi_api_handler.js` file. These secrets are `NCBI_API_EMAIL_SECRET` and `NCBI_TOOL_NAME_SECRET` respectively, and are configured in the repository's GitHub Actions secrets settings.
-3.  Packaging the extension into a `mdpi-filter-extension.zip` file.
-4.  Creating a new GitHub Release associated with the tag and attaching the `mdpi-filter-extension.zip` file as a downloadable asset.
-
----
-
-## ⚙️ Usage
-
-1. **Click** the toolbar icon.  
-2. Choose **Highlight** or **Hide**.  
-3. Perform a search on Google, Scholar, PubMed or Europe PMC—MDPI results will be styled accordingly.  
-4. Open *any* academic article to see MDPI footnotes and bibliography entries styled in-page (no removal).
-
----
-
-## 📄 License
-
-- **Code**: [AGPL-3.0](LICENSE-CODE)  
-- **Logo**: [CC-BY-SA-4.0](LICENSE-LOGO)
-
----
-
-## ⚠️ Known Issues
-
-- **ScienceDirect Author-Year Citations**: On some ScienceDirect articles (e.g., [https://www.sciencedirect.com/science/article/pii/S0924224424001535](https://www.sciencedirect.com/science/article/pii/S0924224424001535)), author-year style inline citations (e.g., "(Balasundram et al., 2023)") are not highlighted for MDPI references. Other functionalities like counting, listing, and highlighting in the reference list work correctly.
-- **ScienceDirect Numerical Citations**: On some ScienceDirect articles (e.g., [https://www.sciencedirect.com/science/article/pii/S1360138520301941](https://www.sciencedirect.com/science/article/pii/S1360138520301941)), inline numerical citations (e.g., "[21]") are not highlighted for MDPI references. Reference list highlighting works correctly.
-- **Nature.com Sidebar References**: On Nature.com articles (e.g., [https://www.nature.com/articles/s44264-024-00042-0](https://www.nature.com/articles/s44264-024-00042-0)), references in the "reading companion" sidebar may occasionally be incorrectly counted and listed in the extension's popup, particularly if an inline footnote is clicked while the page and extension are still loading. While these sidebar references are correctly styled if they are MDPI, they are not intended to be part of the main count.
-- **TheClinics.com Inline Citations**: On TheClinics.com articles (e.g., [https://www.id.theclinics.com/article/S0891-5520(21)00048-9/fulltext](https://www.id.theclinics.com/article/S0891-5520(21)00048-9/fulltext)), inline numerical citations (e.g., "<sup>50</sup>") are not highlighted for MDPI references. Reference list highlighting and other functionalities work correctly.
-- **LWW Journals (Medicine) Issues**:
-    - **Scroll-to-Reference**: On LWW journal pages (e.g., [https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx](https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx)), scrolling to a reference from the popup may not work correctly if the reference list is initially collapsed. The "View full references list" button needs to be manually clicked first.
-    - **Inline Citation Styling**: Inline numerical citations (e.g., "<sup>[4]</sup>") are not highlighted for MDPI references on LWW journal pages (e.g., [https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx](https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx)). Reference list highlighting works correctly.
-- **Wiley Online Library Scroll-to-Reference**: On some Wiley Online Library articles (e.g., [https://onlinelibrary.wiley.com/doi/full/10.1002/vms3.798](https://onlinelibrary.wiley.com/doi/full/10.1002/vms3.798)), scrolling to a reference from the popup may not work if the "REFERENCES" accordion is not manually expanded first. The extension attempts to expand this accordion, but it may not always succeed before the scroll action is triggered.
-- **Limited Citation Data**: On some websites (e.g., LWW journals like [https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx](https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx)), reference items may only provide a Google Scholar link and basic citation text (e.g., authors, title, year, and a journal name like "Aging Clin Exp Res"). Without a DOI or a more specific, unique journal identifier, accurately identifying these as MDPI (or non-MDPI) is challenging. Relying solely on journal names can lead to false positives (if the name is too generic) or false negatives (if the journal name isn't in the extension's known lists or has variations). The extension currently prioritizes DOI, PMCID/PMID (which are converted to DOI where possible), direct link to MDPI domain and strong journal name matches to maintain accuracy. For articles where this is an issue, checking for the full text on [PubMed Central (PMC)](https://pmc.ncbi.nlm.nih.gov/) or [Europe PMC](https://europepmc.org/search?query=SRC%3A%2a%20AND%20%28HAS_FT%3AY%29/) can be a more reliable alternative for MDPI identification if the article is available there. For example, the LWW article mentioned above can be found on PMC ([https://pmc.ncbi.nlm.nih.gov/articles/PMC6750292/](https://pmc.ncbi.nlm.nih.gov/articles/PMC6750292/)), where PMC often provides more precise metadata, including DOI, PMID, and PMCID, which greatly aids in accurate identification.
-
----
-
-## 🧪 Test Pages & Queries
-
-### Test Articles
-
-**Cell**
-- https://www.cell.com/trends/plant-science/abstract/S1360-1385(24)00048-7
-- https://www.cell.com/heliyon/fulltext/S2405-8440(24)17287-8
-
-**BMJ**
-- https://bjsm.bmj.com/content/52/6/376.long
-
-**MDPI**
-- https://www.mdpi.com/1660-4601/20/3/1681
-
-**Frontiers**
-- https://www.frontiersin.org/journals/drug-discovery/articles/10.3389/fddsv.2024.1385460/full
-- https://www.frontiersin.org/journals/nutrition/articles/10.3389/fnut.2024.1439294/full
-
-**Nature**
-- https://www.nature.com/articles/s43016-021-00402-w
-- https://www.nature.com/articles/s41579-023-00993-0
-
-**ScienceDirect**
-- https://www.sciencedirect.com/science/article/pii/S1360138520301941
-
-**NCBI**
-  **PMC (PubMed Central)**
-  - https://pmc.ncbi.nlm.nih.gov/articles/PMC8810379/
-  - https://pmc.ncbi.nlm.nih.gov/articles/PMC9415189/
-  - https://pmc.ncbi.nlm.nih.gov/articles/PMC6750292/
-  **PubMed**
-  - https://pubmed.ncbi.nlm.nih.gov/22971582/
-  - https://pubmed.ncbi.nlm.nih.gov/28805671/
-
-**EuropePMC**
-- https://europepmc.org/article/med/37110471
-- https://europepmc.org/article/pmc/pmc9223600
-
-**The Lancet**
-- https://www.thelancet.com/journals/lanmic/article/PIIS2666-5247(24)00200-3/fulltext
-
-**Oxford Academic**
-- https://academic.oup.com/af/article/13/4/112/7242422
-
-**Wiley Online Library**
-- https://onlinelibrary.wiley.com/doi/full/10.1002/vms3.798
-- https://bpspubs.onlinelibrary.wiley.com/doi/10.1111/bcp.13496
-
-**Sage Journals**
-- https://journals.sagepub.com/doi/abs/10.1177/02698811231200023
-
-**Taylor & Francis Online**
-- https://www.tandfonline.com/doi/full/10.1080/15502783.2024.2441775
-
-**TheClinics.com**
-- https://www.id.theclinics.com/article/S0891-5520(21)00048-9/fulltext
-
-**LWW Journals (Medicine)**
-- https://journals.lww.com/md-journal/fulltext/2019/09130/an_investigation_into_the_stress_relieving_and.67.aspx
-
-### Search Queries
-
-**Google**
-```
-mdpi
-10.3390 europepmc "pmc"
-10.3390 "pmc"
-Poly Lactic-co-Glycolic Acid (PLGA) as Biodegradable Controlled Drug Delivery Carrier
+```bash
+npm ci --ignore-scripts
+npm test
+npm run build
 ```
 
-**Google Scholar**
-```
-mdpi
-10.3390
-"Pattern recognition receptors and the innate immune response to viral infection"
-```
-> The query "Pattern recognition receptors and the innate immune response to viral infection" is included because the MDPI article does not have a direct MDPI link in Scholar results, but does have an NCBI PMC link ([https://pmc.ncbi.nlm.nih.gov/articles/PMC3186011/](https://pmc.ncbi.nlm.nih.gov/articles/PMC3186011/)).
+Generated unpacked extensions appear under:
 
-**PubMed**
-```
-10.3390
+```text
+dist/chrome
+dist/edge
+dist/firefox
+dist/safari
 ```
 
-**EuropePMC**
+Build one target:
+
+```bash
+npm run build:target -- --target edge --version 0.1.0
 ```
-10.3390
-```
 
-### PubMed Articles
-- https://pubmed.ncbi.nlm.nih.gov/22971582/
-- https://pubmed.ncbi.nlm.nih.gov/28805671/
+## Releases
 
-### Other Test Pages
+A protected version tag such as `v0.1.0` triggers the multi-browser release workflow. It:
 
-**Wikipedia**
-- https://en.wikipedia.org/wiki/Autism
+1. Runs the security and regression suite.
+2. Builds all browser targets independently.
+3. Enforces store-specific terminology policies.
+4. Creates reproducible ZIP archives.
+5. Verifies each archive and manifest.
+6. Publishes one GitHub release with all four packages and `checksums.txt`.
 
-**Healthline**
-- https://www.healthline.com/health/nutrition/dietary-supplements
+Store publication is intentionally separate from package creation. The **Publish Browser Store** workflow downloads the already verified release asset, checks its SHA-256 hash, and then uploads or submits it through the official store mechanism behind a protected GitHub Environment.
 
----
+See [Multi-browser releases and store publication](docs/MULTI_BROWSER_RELEASES.md) for the exact account, secret, environment, and migration setup.
+
+## Local installation
+
+### Chrome
+
+1. Build the Chrome target.
+2. Open `chrome://extensions`.
+3. Enable Developer mode.
+4. Select **Load unpacked** and choose `dist/chrome`.
+
+### Microsoft Edge
+
+1. Build the Edge target.
+2. Open `edge://extensions`.
+3. Enable Developer mode.
+4. Select **Load unpacked** and choose `dist/edge`.
+
+### Firefox
+
+1. Build the Firefox target.
+2. Open `about:debugging`.
+3. Select **This Firefox → Load Temporary Add-on**.
+4. Select `dist/firefox/manifest.json`.
+
+Ordinary permanent installation requires Mozilla signing.
+
+### Safari
+
+Build the Safari target and use Safari's temporary web-extension development flow. The generated source package is not an App Store-signed application.
+
+## Security and privacy
+
+The extension:
+
+- Uses Manifest V3.
+- Requests only `storage` as an extension permission.
+- Executes no remote code.
+- Includes no runtime npm dependencies.
+- Sends only bounded scholarly identifiers to documented APIs when network detection is enabled.
+- Omits credentials and referrer information from NCBI requests.
+- Supports a zero-network mode.
+- Uses pinned GitHub Actions and deterministic release inputs.
+
+See [SECURITY.md](SECURITY.md) and the project website for current disclosures.
+
+## Known limitations
+
+Some publisher pages use nonstandard, dynamically loaded, collapsed, or author-year citation structures. Reference-list detection can work even when inline-citation marking or scroll-to-reference cannot be performed safely. False-positive avoidance takes priority over guessing from weak journal-title evidence.
+
+Representative regression pages include PubMed Central, Europe PMC, Nature, Cell, BMJ, ScienceDirect, Wiley, Sage, Taylor & Francis, Oxford Academic, LWW, and Wikipedia pages. Regressions should be filed with the page URL, browser/version, extension version, expected result, and actual result.
+
+## License
+
+- Code: [GNU AGPL-3.0-or-later](LICENSE-CODE)
+- Logo: [CC BY-SA 4.0](LICENSE-LOGO)

--- a/docs/MULTI_BROWSER_RELEASES.md
+++ b/docs/MULTI_BROWSER_RELEASES.md
@@ -1,0 +1,179 @@
+# Multi-browser releases and store publication
+
+This repository is the canonical source for the browser extension. A single source commit generates isolated packages for Chrome, Microsoft Edge, Firefox, and Safari.
+
+## Release outputs
+
+A tag such as `v0.1.0` creates one GitHub release containing:
+
+- `mdpi-filter-chrome-v0.1.0.zip`
+- `mdpi-filter-edge-v0.1.0.zip`
+- `mdpi-filter-firefox-source-v0.1.0.zip`
+- `mdpi-filter-safari-source-v0.1.0.zip`
+- `checksums.txt`
+
+Chrome and Edge receive directly uploadable ZIP packages. Firefox and Safari are deliberately labelled `source`: Firefox must be signed by Mozilla, and Safari must be packaged and signed through Apple before ordinary installation.
+
+All four packages use the same runtime files. `platforms/<target>/manifest.json` contains only the target-specific manifest overlay. `store/<target>/` contains store-specific metadata. `platforms/<target>/policy.json` defines terminology that must not appear in that target's package or listing.
+
+## Local builds
+
+```bash
+npm ci --ignore-scripts
+npm test
+npm run build
+```
+
+The output directories are:
+
+```text
+dist/chrome
+dist/edge
+dist/firefox
+dist/safari
+```
+
+Build one target and optionally override the release version:
+
+```bash
+npm run build:target -- --target edge --version 0.1.0
+```
+
+## GitHub Environments
+
+Create these repository environments under **Settings → Environments**:
+
+- `store-chrome`
+- `store-edge`
+- `store-firefox`
+
+For each environment:
+
+1. Enable **Required reviewers** and select the maintainer account.
+2. Prevent administrator bypass if the repository policy allows it.
+3. Restrict deployment branches and tags to protected release tags.
+4. Add only the secrets required by that store.
+
+A release tag builds and verifies packages automatically. Store publication is a separate manual workflow so a compromised tag or build cannot immediately publish everywhere.
+
+Run publication from **Actions → Publish Browser Store → Run workflow**. Select the store, provide an existing release tag, review the package and checksum, and then choose whether to submit it for review.
+
+## Chrome Web Store setup
+
+The Chrome workflow updates an existing store item through the Chrome Web Store API v2.
+
+Complete these account-level steps once:
+
+1. Enable two-step verification on the publishing Google account.
+2. In Google Cloud Console, create or select a project and enable **Chrome Web Store API**.
+3. Configure the OAuth consent screen.
+4. Create a Web application OAuth client and add `https://developers.google.com/oauthplayground` as an authorized redirect URI.
+5. In OAuth Playground, use the OAuth client and authorize the scope `https://www.googleapis.com/auth/chromewebstore`.
+6. Exchange the authorization code and save the refresh token.
+7. In the Chrome Web Store developer dashboard, record the publisher ID and extension ID.
+8. Complete the Store listing and Privacy tabs. The API cannot replace the required first-time dashboard setup.
+
+Add these secrets to `store-chrome`:
+
+```text
+CHROME_PUBLISHER_ID
+CHROME_EXTENSION_ID
+CHROME_CLIENT_ID
+CHROME_CLIENT_SECRET
+CHROME_REFRESH_TOKEN
+```
+
+With `submit=false`, the workflow uploads the verified ZIP but leaves the item unpublished. With `submit=true`, it also requests review/publication.
+
+## Microsoft Edge Add-ons setup
+
+The Edge workflow updates an existing Partner Center product through the v1.1 API-key flow.
+
+Complete these account-level steps once:
+
+1. Sign in to Partner Center with the account that owns the extension.
+2. Open **Microsoft Edge → Publish API**.
+3. Enable the new API-key experience.
+4. Select **Create API credentials**.
+5. Record the Client ID and API key when they are shown.
+6. Open the extension overview and record its Product ID GUID.
+7. Keep the existing first store submission and listing metadata in Partner Center. The update API cannot create a new product or edit listing metadata.
+
+Add these secrets to `store-edge`:
+
+```text
+EDGE_PRODUCT_ID
+EDGE_CLIENT_ID
+EDGE_API_KEY
+```
+
+Optionally add an environment variable named `EDGE_CERTIFICATION_NOTES`. The workflow otherwise uses a conservative default certification note.
+
+The Edge package and its listing are checked for references to competing stores and browser-specific installation pages before a release can be created.
+
+## Firefox Add-ons setup
+
+The Firefox workflow uses Mozilla's official `web-ext` client and the AMO v5 submission API.
+
+Complete these account-level steps once:
+
+1. Create or sign in to the addons.mozilla.org developer account.
+2. Open the AMO API credentials page.
+3. Generate an API key and secret.
+4. Review `store/firefox/amo-metadata.json`, especially the summary, category, license, and reviewer notes.
+
+Add these secrets to `store-firefox`:
+
+```text
+AMO_JWT_ISSUER
+AMO_JWT_SECRET
+```
+
+The generated Firefox manifest has the stable Manifest V3 ID:
+
+```text
+mdpi-filter@mdpi-filter.org
+```
+
+Do not change this identifier after the first submission. Firefox publication is always a real AMO submission, so the workflow requires `submit=true`.
+
+## Safari status
+
+The release workflow creates a Safari-compatible source package and removes metadata that Safari does not need. It does not publish to the App Store yet.
+
+Public Safari distribution still requires:
+
+1. Apple Developer Program membership.
+2. An App Store Connect app record.
+3. A verified physical-device test on current macOS and iOS Safari.
+4. Safari Web Extension Packager or Xcode packaging.
+5. App Store privacy disclosures, screenshots, signing, and review information.
+6. App Store Connect API access and narrowly scoped API credentials before publication automation is enabled.
+
+Until those gates are met, use the Safari source package for local compatibility testing and do not advertise it as an installable App Store release.
+
+## Migrating the dedicated Edge repository
+
+Do not archive the dedicated Edge repository before the first Edge update produced from this repository has passed certification.
+
+Migration sequence:
+
+1. Merge the multi-browser pipeline.
+2. Create and inspect a prerelease tag.
+3. Compare the generated Edge ZIP with the existing Edge package.
+4. Publish one Edge update through the protected workflow.
+5. Confirm installation, updates, permissions, and store listing links.
+6. Replace the old repository README with a migration notice pointing to this repository.
+7. Archive the old repository as read-only.
+
+Do not maintain a generated code mirror unless a store reviewer specifically requires it. The store-specific package and metadata are sufficient separation; the runtime source must remain canonical here.
+
+## Release safety properties
+
+- Store packages are built from one source commit.
+- Store-specific terms and manifests are generated, not manually copied.
+- Actions are pinned to full commit hashes.
+- The release workflow publishes only artifacts that passed the test job.
+- Store workflows download the existing release artifacts and verify SHA-256 checksums instead of rebuilding.
+- Each store has separate credentials and a separate protected GitHub Environment.
+- Store submission remains independently approvable.

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
     "default_popup": "popup.html"
   },
   "options_page": "options.html",
-  "homepage_url": "https://mdpi-filter.github.io/mdpi-filter-chrome/",
+  "homepage_url": "https://mdpi-filter.pages.dev/",
   "content_scripts": [
     {
       "matches": [
@@ -64,5 +64,7 @@
       "run_at": "document_idle"
     }
   ],
-  "externally_connectable": { "matches": [] }
+  "externally_connectable": {
+    "matches": []
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mdpi-filter-chrome",
+  "name": "mdpi-filter-browser-extension",
   "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mdpi-filter-chrome",
+      "name": "mdpi-filter-browser-extension",
       "version": "0.0.4",
       "license": "AGPL-3.0-or-later"
     }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
-  "name": "mdpi-filter-chrome",
+  "name": "mdpi-filter-browser-extension",
   "version": "0.0.4",
   "private": true,
-  "description": "Chrome extension that identifies and manages MDPI publications.",
+  "description": "Cross-browser extension that identifies and manages MDPI publications.",
   "scripts": {
-    "build": "node scripts/verify-extension.js",
+    "build": "node scripts/build-all.js",
+    "build:target": "node scripts/build-target.js",
+    "verify": "node scripts/verify-extension.js",
     "test": "node scripts/verify-extension.js && node --test tests/*.test.js"
   },
   "license": "AGPL-3.0-or-later"

--- a/platforms/chrome/manifest.json
+++ b/platforms/chrome/manifest.json
@@ -1,0 +1,3 @@
+{
+  "homepage_url": "https://mdpi-filter.pages.dev/"
+}

--- a/platforms/chrome/policy.json
+++ b/platforms/chrome/policy.json
@@ -1,0 +1,7 @@
+{
+  "forbiddenTerms": [
+    "Microsoft Edge Add-ons",
+    "Mozilla Add-ons",
+    "Safari Extensions Gallery"
+  ]
+}

--- a/platforms/edge/manifest.json
+++ b/platforms/edge/manifest.json
@@ -1,0 +1,3 @@
+{
+  "homepage_url": "https://mdpi-filter.pages.dev/"
+}

--- a/platforms/edge/policy.json
+++ b/platforms/edge/policy.json
@@ -1,0 +1,11 @@
+{
+  "forbiddenTerms": [
+    "Chrome Web Store",
+    "Google Chrome",
+    "chrome://extensions",
+    "Mozilla Add-ons",
+    "Firefox Add-ons",
+    "Safari Extensions Gallery",
+    "Apple App Store"
+  ]
+}

--- a/platforms/firefox/manifest.json
+++ b/platforms/firefox/manifest.json
@@ -1,0 +1,16 @@
+{
+  "homepage_url": "https://mdpi-filter.pages.dev/",
+  "background": {
+    "service_worker": null,
+    "type": null,
+    "scripts": [
+      "background.js"
+    ]
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "mdpi-filter@mdpi-filter.org",
+      "strict_min_version": "128.0"
+    }
+  }
+}

--- a/platforms/firefox/policy.json
+++ b/platforms/firefox/policy.json
@@ -1,0 +1,7 @@
+{
+  "forbiddenTerms": [
+    "Chrome Web Store",
+    "Microsoft Edge Add-ons",
+    "Safari Extensions Gallery"
+  ]
+}

--- a/platforms/safari/manifest.json
+++ b/platforms/safari/manifest.json
@@ -1,0 +1,4 @@
+{
+  "homepage_url": "https://mdpi-filter.pages.dev/",
+  "externally_connectable": null
+}

--- a/platforms/safari/policy.json
+++ b/platforms/safari/policy.json
@@ -1,0 +1,7 @@
+{
+  "forbiddenTerms": [
+    "Chrome Web Store",
+    "Microsoft Edge Add-ons",
+    "Mozilla Add-ons"
+  ]
+}

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { buildTarget } = require('./build-target');
+
+const ROOT = path.resolve(__dirname, '..');
+const TARGETS = ['chrome', 'edge', 'firefox', 'safari'];
+
+function readVersionArgument(argv) {
+  const index = argv.indexOf('--version');
+  if (index === -1) return null;
+  if (!argv[index + 1]) throw new Error('Missing value for --version');
+  return argv[index + 1];
+}
+
+const releaseVersion = readVersionArgument(process.argv.slice(2));
+fs.rmSync(path.join(ROOT, 'dist'), { recursive: true, force: true });
+for (const target of TARGETS) buildTarget(target, releaseVersion);
+console.log(`Built ${TARGETS.length} browser targets.`);

--- a/scripts/build-target.js
+++ b/scripts/build-target.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const TARGETS = new Set(['chrome', 'edge', 'firefox', 'safari']);
+const OMIT_TOP_LEVEL = new Set([
+  '.git',
+  '.github',
+  'dist',
+  'docs',
+  'node_modules',
+  'platforms',
+  'scripts',
+  'store',
+  'tests'
+]);
+const OMIT_ROOT_FILES = new Set([
+  '.gitattributes',
+  '.gitignore',
+  'package.json',
+  'package-lock.json',
+  'README.md',
+  'SECURITY.md',
+  'renovate.json'
+]);
+const DELETE = Symbol('delete');
+
+function fail(message) {
+  throw new Error(`Target build failed: ${message}`);
+}
+
+function parseArguments(argv) {
+  const args = { target: null, releaseVersion: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--target') args.target = argv[++index];
+    else if (value === '--version') args.releaseVersion = argv[++index];
+    else fail(`unknown argument: ${value}`);
+  }
+  if (!TARGETS.has(args.target)) fail(`unsupported target: ${args.target || '(missing)'}`);
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function mergeValue(base, overlay) {
+  if (overlay === null) return DELETE;
+  if (Array.isArray(overlay)) return overlay.map(value => structuredClone(value));
+  if (overlay && typeof overlay === 'object') {
+    const result = base && typeof base === 'object' && !Array.isArray(base)
+      ? structuredClone(base)
+      : {};
+    for (const [key, value] of Object.entries(overlay)) {
+      const merged = mergeValue(result[key], value);
+      if (merged === DELETE) delete result[key];
+      else result[key] = merged;
+    }
+    return result;
+  }
+  return overlay;
+}
+
+function normalizeVersion(input, fallback) {
+  const releaseVersion = String(input || fallback || '').replace(/^v/, '');
+  const manifestVersion = releaseVersion.split('-', 1)[0];
+  if (!/^\d+(?:\.\d+){0,3}$/.test(manifestVersion)) {
+    fail(`invalid browser manifest version: ${releaseVersion}`);
+  }
+  if (releaseVersion && !/^\d+(?:\.\d+){0,3}(?:-[0-9A-Za-z.-]+)?$/.test(releaseVersion)) {
+    fail(`invalid release version: ${releaseVersion}`);
+  }
+  return { releaseVersion, manifestVersion };
+}
+
+function shouldOmit(relativePath) {
+  const normalized = relativePath.split(path.sep).join('/');
+  const [topLevel] = normalized.split('/');
+  if (OMIT_TOP_LEVEL.has(topLevel)) return true;
+  if (!normalized.includes('/') && OMIT_ROOT_FILES.has(normalized)) return true;
+  if (normalized === 'manifest.json') return true;
+  return /\.(?:zip|xpi)$/i.test(normalized);
+}
+
+function copyRuntimeFiles(sourceDirectory, destinationDirectory, relativeDirectory = '') {
+  for (const entry of fs.readdirSync(sourceDirectory, { withFileTypes: true })) {
+    const relativePath = path.join(relativeDirectory, entry.name);
+    if (shouldOmit(relativePath)) continue;
+    const sourcePath = path.join(sourceDirectory, entry.name);
+    const destinationPath = path.join(destinationDirectory, relativePath);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(destinationPath, { recursive: true });
+      copyRuntimeFiles(sourcePath, destinationDirectory, relativePath);
+    } else if (entry.isFile()) {
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.copyFileSync(sourcePath, destinationPath);
+    }
+  }
+}
+
+function collectTextFiles(directory, predicate, output = []) {
+  if (!fs.existsSync(directory)) return output;
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) collectTextFiles(absolutePath, predicate, output);
+    else if (entry.isFile() && predicate(absolutePath)) output.push(absolutePath);
+  }
+  return output;
+}
+
+function verifyPolicy(target, destinationDirectory) {
+  const policyPath = path.join(ROOT, 'platforms', target, 'policy.json');
+  if (!fs.existsSync(policyPath)) return;
+  const policy = readJson(policyPath);
+  const forbiddenTerms = Array.isArray(policy.forbiddenTerms) ? policy.forbiddenTerms : [];
+  if (forbiddenTerms.length === 0) return;
+
+  const packageFiles = collectTextFiles(destinationDirectory, filePath => /\.(?:html|json|md|txt)$/i.test(filePath));
+  const storeDirectory = path.join(ROOT, 'store', target);
+  const storeFiles = collectTextFiles(storeDirectory, filePath => /\.(?:html|json|md|txt)$/i.test(filePath));
+  const violations = [];
+
+  for (const filePath of [...packageFiles, ...storeFiles]) {
+    const source = fs.readFileSync(filePath, 'utf8');
+    for (const term of forbiddenTerms) {
+      if (source.toLocaleLowerCase('en-US').includes(String(term).toLocaleLowerCase('en-US'))) {
+        violations.push(`${path.relative(ROOT, filePath)} contains forbidden term ${JSON.stringify(term)}`);
+      }
+    }
+  }
+
+  if (violations.length > 0) fail(`${target} policy violations:\n${violations.join('\n')}`);
+}
+
+function verifyManifestFiles(manifest, destinationDirectory) {
+  const referencedFiles = new Set();
+  if (manifest.background?.service_worker) referencedFiles.add(manifest.background.service_worker);
+  for (const backgroundScript of manifest.background?.scripts || []) referencedFiles.add(backgroundScript);
+  if (manifest.action?.default_popup) referencedFiles.add(manifest.action.default_popup);
+  if (manifest.options_page) referencedFiles.add(manifest.options_page);
+  for (const contentScript of manifest.content_scripts || []) {
+    for (const file of contentScript.js || []) referencedFiles.add(file);
+    for (const file of contentScript.css || []) referencedFiles.add(file);
+  }
+  for (const relativePath of referencedFiles) {
+    if (!fs.existsSync(path.join(destinationDirectory, relativePath))) {
+      fail(`manifest references missing file: ${relativePath}`);
+    }
+  }
+}
+
+function buildTarget(target, releaseVersionInput) {
+  const packageJson = readJson(path.join(ROOT, 'package.json'));
+  const baseManifest = readJson(path.join(ROOT, 'manifest.json'));
+  const overlay = readJson(path.join(ROOT, 'platforms', target, 'manifest.json'));
+  const { releaseVersion, manifestVersion } = normalizeVersion(releaseVersionInput, packageJson.version);
+  const manifest = mergeValue(baseManifest, overlay);
+  manifest.version = manifestVersion;
+  if (releaseVersion !== manifestVersion) manifest.version_name = releaseVersion;
+  else delete manifest.version_name;
+
+  const destinationDirectory = path.join(ROOT, 'dist', target);
+  fs.rmSync(destinationDirectory, { recursive: true, force: true });
+  fs.mkdirSync(destinationDirectory, { recursive: true });
+  copyRuntimeFiles(ROOT, destinationDirectory);
+  fs.writeFileSync(path.join(destinationDirectory, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+
+  verifyManifestFiles(manifest, destinationDirectory);
+  verifyPolicy(target, destinationDirectory);
+  console.log(`Built ${target} extension in ${path.relative(ROOT, destinationDirectory)}`);
+  return destinationDirectory;
+}
+
+if (require.main === module) {
+  const args = parseArguments(process.argv.slice(2));
+  buildTarget(args.target, args.releaseVersion);
+}
+
+module.exports = { buildTarget, mergeValue, normalizeVersion };

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('node:fs');
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+async function parseResponse(response, operation) {
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    data = { raw: text.slice(0, 2000) };
+  }
+  if (!response.ok) {
+    throw new Error(`${operation} failed with HTTP ${response.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function sleep(milliseconds) {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  const packagePath = process.argv[2];
+  if (!packagePath || !fs.existsSync(packagePath)) throw new Error('A valid Chrome package path is required');
+
+  const publisherId = required('CHROME_PUBLISHER_ID');
+  const extensionId = required('CHROME_EXTENSION_ID');
+  const clientId = required('CHROME_CLIENT_ID');
+  const clientSecret = required('CHROME_CLIENT_SECRET');
+  const refreshToken = required('CHROME_REFRESH_TOKEN');
+  const submit = process.env.SUBMIT === 'true';
+
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token'
+    })
+  });
+  const tokenData = await parseResponse(tokenResponse, 'Chrome OAuth token refresh');
+  if (!tokenData.access_token) throw new Error('Chrome OAuth response did not contain an access token');
+
+  const itemBase = `https://chromewebstore.googleapis.com/v2/publishers/${encodeURIComponent(publisherId)}/items/${encodeURIComponent(extensionId)}`;
+  const authorization = `Bearer ${tokenData.access_token}`;
+  const uploadResponse = await fetch(
+    `https://chromewebstore.googleapis.com/upload/v2/publishers/${encodeURIComponent(publisherId)}/items/${encodeURIComponent(extensionId)}:upload`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: authorization,
+        'Content-Type': 'application/zip'
+      },
+      body: fs.readFileSync(packagePath)
+    }
+  );
+  let uploadData = await parseResponse(uploadResponse, 'Chrome package upload');
+
+  for (let attempt = 0; uploadData.uploadState === 'UPLOAD_IN_PROGRESS' && attempt < 60; attempt += 1) {
+    await sleep(10_000);
+    const statusResponse = await fetch(`${itemBase}:fetchStatus`, {
+      headers: { Authorization: authorization }
+    });
+    uploadData = await parseResponse(statusResponse, 'Chrome upload status');
+  }
+
+  if (uploadData.uploadState && uploadData.uploadState !== 'SUCCEEDED') {
+    throw new Error(`Chrome upload did not succeed: ${JSON.stringify(uploadData)}`);
+  }
+  console.log('Chrome package upload succeeded.');
+
+  if (!submit) {
+    console.log('Chrome publication was not requested; the uploaded draft remains unpublished.');
+    return;
+  }
+
+  const publishResponse = await fetch(`${itemBase}:publish`, {
+    method: 'POST',
+    headers: { Authorization: authorization }
+  });
+  const publishData = await parseResponse(publishResponse, 'Chrome publication request');
+  console.log(`Chrome publication request accepted: ${JSON.stringify(publishData)}`);
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -73,7 +73,7 @@ async function main() {
     uploadData = await parseResponse(statusResponse, 'Chrome upload status');
   }
 
-  if (uploadData.uploadState && uploadData.uploadState !== 'SUCCEEDED') {
+  if (uploadData.uploadState !== 'SUCCEEDED') {
     throw new Error(`Chrome upload did not succeed: ${JSON.stringify(uploadData)}`);
   }
   console.log('Chrome package upload succeeded.');

--- a/scripts/publish-edge.js
+++ b/scripts/publish-edge.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const fs = require('node:fs');
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+async function parseResponse(response, operation) {
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    data = { raw: text.slice(0, 2000) };
+  }
+  if (!response.ok) {
+    throw new Error(`${operation} failed with HTTP ${response.status}: ${JSON.stringify(data)}`);
+  }
+  return { data, location: response.headers.get('location') };
+}
+
+async function sleep(milliseconds) {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function pollOperation(url, headers, operation) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const response = await fetch(url, { headers });
+    const { data } = await parseResponse(response, operation);
+    if (data.status === 'Succeeded') return data;
+    if (data.status === 'Failed') throw new Error(`${operation} failed: ${JSON.stringify(data)}`);
+    await sleep(10_000);
+  }
+  throw new Error(`${operation} did not complete within ten minutes`);
+}
+
+function operationId(location) {
+  if (!location) throw new Error('Microsoft Edge API response did not include a Location operation ID');
+  return location.split('/').filter(Boolean).pop();
+}
+
+async function main() {
+  const packagePath = process.argv[2];
+  if (!packagePath || !fs.existsSync(packagePath)) throw new Error('A valid Edge package path is required');
+
+  const productId = required('EDGE_PRODUCT_ID');
+  const clientId = required('EDGE_CLIENT_ID');
+  const apiKey = required('EDGE_API_KEY');
+  const submit = process.env.SUBMIT === 'true';
+  const baseUrl = 'https://api.addons.microsoftedge.microsoft.com/v1';
+  const headers = {
+    Authorization: `ApiKey ${apiKey}`,
+    'X-ClientID': clientId
+  };
+
+  const uploadResponse = await fetch(`${baseUrl}/products/${encodeURIComponent(productId)}/submissions/draft/package`, {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'Content-Type': 'application/zip'
+    },
+    body: fs.readFileSync(packagePath)
+  });
+  const upload = await parseResponse(uploadResponse, 'Edge package upload');
+  const uploadId = operationId(upload.location);
+  await pollOperation(
+    `${baseUrl}/products/${encodeURIComponent(productId)}/submissions/draft/package/operations/${encodeURIComponent(uploadId)}`,
+    headers,
+    'Edge package processing'
+  );
+  console.log('Edge package upload succeeded.');
+
+  if (!submit) {
+    console.log('Edge publication was not requested; the uploaded draft remains unpublished.');
+    return;
+  }
+
+  const notes = process.env.EDGE_CERTIFICATION_NOTES
+    || 'Automated submission from the verified GitHub release artifact. No remote code or telemetry is included.';
+  const publishResponse = await fetch(`${baseUrl}/products/${encodeURIComponent(productId)}/submissions`, {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'Content-Type': 'text/plain; charset=utf-8'
+    },
+    body: notes
+  });
+  const publication = await parseResponse(publishResponse, 'Edge publication request');
+  const publicationId = operationId(publication.location);
+  const result = await pollOperation(
+    `${baseUrl}/products/${encodeURIComponent(productId)}/submissions/operations/${encodeURIComponent(publicationId)}`,
+    headers,
+    'Edge publication processing'
+  );
+  console.log(`Edge publication request succeeded: ${JSON.stringify(result)}`);
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/store/chrome/listing.json
+++ b/store/chrome/listing.json
@@ -1,0 +1,6 @@
+{
+  "name": "MDPI Filter",
+  "summary": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections.",
+  "homepage": "https://mdpi-filter.pages.dev/",
+  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/chrome"
+}

--- a/store/edge/listing.json
+++ b/store/edge/listing.json
@@ -1,0 +1,6 @@
+{
+  "name": "MDPI Filter",
+  "summary": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections.",
+  "homepage": "https://mdpi-filter.pages.dev/",
+  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/edge"
+}

--- a/store/firefox/amo-metadata.json
+++ b/store/firefox/amo-metadata.json
@@ -1,0 +1,15 @@
+{
+  "summary": {
+    "en-US": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections."
+  },
+  "categories": [
+    "other"
+  ],
+  "homepage": {
+    "en-US": "https://mdpi-filter.pages.dev/"
+  },
+  "version": {
+    "license": "AGPL-3.0-only",
+    "approval_notes": "The submitted package is generated from the public repository without minification, bundling, remote code, or runtime npm dependencies."
+  }
+}

--- a/store/safari/listing.json
+++ b/store/safari/listing.json
@@ -1,0 +1,6 @@
+{
+  "name": "MDPI Filter",
+  "summary": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections.",
+  "homepage": "https://mdpi-filter.pages.dev/",
+  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/safari"
+}

--- a/tests/multi-browser.test.js
+++ b/tests/multi-browser.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.join(ROOT, 'dist');
+
+function readManifest(target) {
+  return JSON.parse(fs.readFileSync(path.join(DIST, target, 'manifest.json'), 'utf8'));
+}
+
+test('one source tree generates isolated browser packages', () => {
+  fs.rmSync(DIST, { recursive: true, force: true });
+  try {
+    const result = spawnSync(process.execPath, [
+      path.join(ROOT, 'scripts', 'build-all.js'),
+      '--version',
+      '1.2.3-beta.1'
+    ], { cwd: ROOT, encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const chrome = readManifest('chrome');
+    const edge = readManifest('edge');
+    const firefox = readManifest('firefox');
+    const safari = readManifest('safari');
+
+    for (const manifest of [chrome, edge, firefox, safari]) {
+      assert.equal(manifest.version, '1.2.3');
+      assert.equal(manifest.version_name, '1.2.3-beta.1');
+      assert.equal(manifest.homepage_url, 'https://mdpi-filter.pages.dev/');
+      assert.deepEqual(manifest.permissions, ['storage']);
+    }
+
+    assert.equal(chrome.background.service_worker, 'background.js');
+    assert.equal(edge.background.service_worker, 'background.js');
+    assert.deepEqual(firefox.background.scripts, ['background.js']);
+    assert.equal(Object.hasOwn(firefox.background, 'service_worker'), false);
+    assert.equal(Object.hasOwn(firefox.background, 'type'), false);
+    assert.equal(firefox.browser_specific_settings.gecko.id, 'mdpi-filter@mdpi-filter.org');
+    assert.equal(Object.hasOwn(safari, 'externally_connectable'), false);
+
+    for (const target of ['chrome', 'edge', 'firefox', 'safari']) {
+      assert.equal(fs.existsSync(path.join(DIST, target, 'background.js')), true);
+      assert.equal(fs.existsSync(path.join(DIST, target, 'content', 'content_script.js')), true);
+      assert.equal(fs.existsSync(path.join(DIST, target, 'scripts')), false);
+      assert.equal(fs.existsSync(path.join(DIST, target, 'tests')), false);
+    }
+  } finally {
+    fs.rmSync(DIST, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- makes this repository the canonical source for Chrome, Microsoft Edge, Firefox, and Safari packages
- adds target-specific manifest overlays and store metadata
- enforces store terminology isolation, including Microsoft Edge restrictions
- generates four reproducible release assets plus SHA-256 checksums from one version tag
- adds protected Chrome, Edge, and Firefox publication workflows using official store mechanisms
- keeps Safari source-only until Apple distribution is economically and operationally justified
- documents exact GitHub Environment, credential, account, and Edge-repository migration steps

## Safety properties

- shared runtime code is never copied into hand-maintained browser repositories
- target packages are generated and tested from one commit
- store publication downloads verified GitHub release assets instead of rebuilding
- each store uses separate credentials and a protected GitHub Environment
- Chrome and Edge support upload-only mode before submission
- Firefox uses a stable Manifest V3 ID and Mozilla's official `web-ext` client

## Validation

- existing security and regression suite
- new cross-browser generation test
- PR workflow builds and validates all four generated manifests and required runtime files

## Migration

The dedicated Edge repository should remain available until one Edge update produced by this pipeline passes certification. It can then be replaced with a migration notice and archived.

## Release-version note

Prerelease tags are for GitHub artifact validation only. Because browser manifests use numeric versions, `v0.0.5-rc.1` produces manifest version `0.0.5`; do not upload that prerelease package to a store if `v0.0.5` is intended as the stable store release.