### PR TITLE
Block prerelease packages from browser-store submission

### DIFF
--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -12,7 +12,7 @@ on:
           - edge
           - firefox
       tag:
-        description: Existing GitHub release tag, for example v0.1.0
+        description: Existing stable GitHub release tag, for example v0.1.0
         required: true
         type: string
       submit:
@@ -33,13 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: store-${{ inputs.store }}
     steps:
-      - name: Validate requested tag
+      - name: Validate stable release tag
         shell: bash
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){0,3}(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid release tag: $TAG" >&2
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){0,3}$ ]]; then
+            echo "Store publication requires a stable numeric tag such as v0.1.0; prerelease tags are rejected: $TAG" >&2
             exit 1
           fi
 

--- a/docs/MULTI_BROWSER_RELEASES.md
+++ b/docs/MULTI_BROWSER_RELEASES.md
@@ -16,6 +16,14 @@ Chrome and Edge receive directly uploadable ZIP packages. Firefox and Safari are
 
 All four packages use the same runtime files. `platforms/<target>/manifest.json` contains only the target-specific manifest overlay. `store/<target>/` contains store-specific metadata. `platforms/<target>/policy.json` defines terminology that must not appear in that target's package or listing.
 
+## Stable and prerelease versions
+
+GitHub prerelease tags such as `v0.1.0-rc.1` are useful for building and inspecting candidate artifacts. They must not be uploaded to browser stores.
+
+Browser manifests accept numeric versions, so the build converts both `v0.1.0-rc.1` and `v0.1.0` to manifest version `0.1.0`, while preserving the full candidate label only as `version_name` where supported. Uploading the candidate could therefore consume the numeric version needed by the intended stable release.
+
+The **Publish Browser Store** workflow enforces this boundary and accepts only stable numeric tags such as `v0.1.0` or `v0.1.0.1`. Use prerelease tags only for GitHub artifact validation, then create a stable tag after the candidate passes testing.
+
 ## Local builds
 
 ```bash
@@ -56,7 +64,7 @@ For each environment:
 
 A release tag builds and verifies packages automatically. Store publication is a separate manual workflow so a compromised tag or build cannot immediately publish everywhere.
 
-Run publication from **Actions → Publish Browser Store → Run workflow**. Select the store, provide an existing release tag, review the package and checksum, and then choose whether to submit it for review.
+Run publication from **Actions → Publish Browser Store → Run workflow**. Select the store, provide an existing stable release tag, review the package and checksum, and then choose whether to submit it for review. Prerelease tags are rejected before any credential is used.
 
 ## Chrome Web Store setup
 
@@ -159,12 +167,13 @@ Do not archive the dedicated Edge repository before the first Edge update produc
 Migration sequence:
 
 1. Merge the multi-browser pipeline.
-2. Create and inspect a prerelease tag.
-3. Compare the generated Edge ZIP with the existing Edge package.
-4. Publish one Edge update through the protected workflow.
-5. Confirm installation, updates, permissions, and store listing links.
-6. Replace the old repository README with a migration notice pointing to this repository.
-7. Archive the old repository as read-only.
+2. Create and inspect a GitHub-only prerelease tag.
+3. Compare the generated Edge ZIP with the existing Edge package without uploading the prerelease to the store.
+4. Create a stable numeric release tag after validation.
+5. Publish one Edge update through the protected workflow.
+6. Confirm installation, updates, permissions, and store listing links.
+7. Replace the old repository README with a migration notice pointing to this repository.
+8. Archive the old repository as read-only.
 
 Do not maintain a generated code mirror unless a store reviewer specifically requires it. The store-specific package and metadata are sufficient separation; the runtime source must remain canonical here.
 
@@ -175,5 +184,6 @@ Do not maintain a generated code mirror unless a store reviewer specifically req
 - Actions are pinned to full commit hashes.
 - The release workflow publishes only artifacts that passed the test job.
 - Store workflows download the existing release artifacts and verify SHA-256 checksums instead of rebuilding.
+- Store publication rejects prerelease tags before using provider credentials.
 - Each store has separate credentials and a separate protected GitHub Environment.
 - Store submission remains independently approvable.

--- a/tests/store-release-policy.test.js
+++ b/tests/store-release-policy.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const workflowPath = path.resolve(__dirname, '..', '.github', 'workflows', 'publish-store.yml');
+
+test('store publication rejects prerelease tags', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /Store publication requires a stable numeric tag/);
+  assert.match(workflow, /\^v\[0-9\]\+\(\\\.\[0-9\]\+\)\{0,3\}\$/);
+  assert.doesNotMatch(workflow, /\(-\[0-9A-Za-z\.\-\]\+\)\?/);
+});


### PR DESCRIPTION
## Summary

- restricts the store publication workflow to stable numeric tags
- prevents release candidates such as `v0.0.5-rc.1` from consuming the numeric store version `0.0.5`
- adds a regression test for the workflow policy
- documents the GitHub-prerelease versus store-release boundary

GitHub prereleases remain supported for artifact inspection; only store submission is blocked.