### PR TITLE
Support verified CRX uploads in Chrome publication

### DIFF
--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -92,6 +92,52 @@ jobs:
           test -f "$PACKAGE"
           echo "path=$PACKAGE" >> "$GITHUB_OUTPUT"
 
+      - name: Sign Chrome package as verified CRX
+        if: inputs.store == 'chrome'
+        id: chrome_crx
+        shell: bash
+        env:
+          SOURCE_ZIP: ${{ steps.package.outputs.path }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CRX_PRIVATE_KEY_B64: ${{ secrets.CHROME_CRX_PRIVATE_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$CHROME_CRX_PRIVATE_KEY_B64" ]]; then
+            echo "Missing CHROME_CRX_PRIVATE_KEY_B64 in the store-chrome environment." >&2
+            exit 1
+          fi
+
+          umask 077
+          WORK_DIR="$RUNNER_TEMP/mdpi-filter-chrome-extension"
+          KEY_PATH="$RUNNER_TEMP/mdpi-filter-chrome-private-key.pem"
+          OUTPUT_PATH="release-assets/$(basename "${SOURCE_ZIP%.zip}").crx"
+          cleanup() {
+            rm -rf "$WORK_DIR" "$KEY_PATH" "$WORK_DIR.crx"
+          }
+          trap cleanup EXIT
+
+          rm -rf "$WORK_DIR" "$KEY_PATH" "$WORK_DIR.crx" "$OUTPUT_PATH"
+          mkdir -p "$WORK_DIR"
+          printf '%s' "$CHROME_CRX_PRIVATE_KEY_B64" | base64 --decode > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          openssl pkey -in "$KEY_PATH" -check -noout
+
+          DERIVED_EXTENSION_ID="$(
+            openssl pkey -in "$KEY_PATH" -pubout -outform DER \
+              | node -e "const crypto=require('node:crypto');const chunks=[];process.stdin.on('data',d=>chunks.push(d));process.stdin.on('end',()=>{const hex=crypto.createHash('sha256').update(Buffer.concat(chunks)).digest('hex').slice(0,32);process.stdout.write([...hex].map(c=>String.fromCharCode(97+parseInt(c,16))).join(''));});"
+          )"
+          if [[ "$DERIVED_EXTENSION_ID" != "$CHROME_EXTENSION_ID" ]]; then
+            echo "The CRX signing key does not match CHROME_EXTENSION_ID." >&2
+            exit 1
+          fi
+
+          unzip -q "$SOURCE_ZIP" -d "$WORK_DIR"
+          command -v google-chrome >/dev/null
+          google-chrome --pack-extension="$WORK_DIR" --pack-extension-key="$KEY_PATH"
+          test -s "$WORK_DIR.crx"
+          mv "$WORK_DIR.crx" "$OUTPUT_PATH"
+          echo "path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Upload or publish Chrome package
         if: inputs.store == 'chrome'
         env:
@@ -101,7 +147,7 @@ jobs:
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
           SUBMIT: ${{ inputs.submit }}
-        run: node scripts/publish-chrome.js "${{ steps.package.outputs.path }}"
+        run: node scripts/publish-chrome.js "${{ steps.chrome_crx.outputs.path }}"
 
       - name: Upload or publish Edge package
         if: inputs.store == 'edge'

--- a/docs/MULTI_BROWSER_RELEASES.md
+++ b/docs/MULTI_BROWSER_RELEASES.md
@@ -12,7 +12,7 @@ A tag such as `v0.1.0` creates one GitHub release containing:
 - `mdpi-filter-safari-source-v0.1.0.zip`
 - `checksums.txt`
 
-Chrome and Edge receive directly uploadable ZIP packages. Firefox and Safari are deliberately labelled `source`: Firefox must be signed by Mozilla, and Safari must be packaged and signed through Apple before ordinary installation.
+The Edge ZIP is directly uploadable. The Chrome ZIP is the checksummed canonical package input: because Verified CRX Uploads are enabled, the protected `store-chrome` workflow signs that ZIP with the registered private key and uploads a generated `.crx`. Firefox and Safari are deliberately labelled `source`: Firefox must be signed by Mozilla, and Safari must be packaged and signed through Apple before ordinary installation.
 
 All four packages use the same runtime files. `platforms/<target>/manifest.json` contains only the target-specific manifest overlay. `store/<target>/` contains store-specific metadata. `platforms/<target>/policy.json` defines terminology that must not appear in that target's package or listing.
 
@@ -59,7 +59,7 @@ For each environment:
 
 1. Enable **Required reviewers** and select the maintainer account.
 2. Prevent administrator bypass if the repository policy allows it.
-3. Restrict deployment branches and tags to protected release tags.
+3. Restrict deployment to the `main` branch. The publication workflow is manually dispatched from `main`; the immutable release tag is supplied as an input and checked out inside the job.
 4. Add only the secrets required by that store.
 
 A release tag builds and verifies packages automatically. Store publication is a separate manual workflow so a compromised tag or build cannot immediately publish everywhere.
@@ -68,7 +68,7 @@ Run publication from **Actions → Publish Browser Store → Run workflow**. Sel
 
 ## Chrome Web Store setup
 
-The Chrome workflow updates an existing store item through the Chrome Web Store API v2.
+The Chrome workflow updates an existing store item through the Chrome Web Store API v2 and supports the item's Verified CRX Uploads requirement.
 
 Complete these account-level steps once:
 
@@ -80,6 +80,7 @@ Complete these account-level steps once:
 6. Exchange the authorization code and save the refresh token.
 7. In the Chrome Web Store developer dashboard, record the publisher ID and extension ID.
 8. Complete the Store listing and Privacy tabs. The API cannot replace the required first-time dashboard setup.
+9. Keep the exact RSA private key whose public key was registered when Verified CRX Uploads were enabled.
 
 Add these secrets to `store-chrome`:
 
@@ -89,9 +90,22 @@ CHROME_EXTENSION_ID
 CHROME_CLIENT_ID
 CHROME_CLIENT_SECRET
 CHROME_REFRESH_TOKEN
+CHROME_CRX_PRIVATE_KEY_B64
 ```
 
-With `submit=false`, the workflow uploads the verified ZIP but leaves the item unpublished. With `submit=true`, it also requests review/publication.
+Create the base64 value locally without changing the key:
+
+```bash
+base64 < privatekey.pem | tr -d '\n'
+```
+
+Paste only that output into the `CHROME_CRX_PRIVATE_KEY_B64` environment secret. Never commit the PEM file, paste it into an issue, or store it in the Chrome Web Store account. Keep at least one encrypted offline backup independent of GitHub; losing the key requires Chrome Web Store support and can delay updates.
+
+The workflow reconstructs the key only in the runner's temporary directory with restrictive permissions, validates it with OpenSSL, derives the Chrome extension ID from its public key, and fails if it does not match `CHROME_EXTENSION_ID`. It then signs the checksummed Chrome ZIP with the installed Google Chrome binary, deletes temporary key material, and uploads the resulting CRX with the required raw-upload headers.
+
+With `submit=false`, the workflow signs and uploads the verified CRX but leaves the item unpublished. With `submit=true`, it also requests review/publication.
+
+For the strongest possible separation, keep the signing key entirely offline and sign/upload CRX files manually instead of storing `CHROME_CRX_PRIVATE_KEY_B64` in GitHub. The protected environment approach provides automation while keeping the key outside the Google publisher account and requiring an explicit deployment approval.
 
 ## Microsoft Edge Add-ons setup
 
@@ -184,6 +198,7 @@ Do not maintain a generated code mirror unless a store reviewer specifically req
 - Actions are pinned to full commit hashes.
 - The release workflow publishes only artifacts that passed the test job.
 - Store workflows download the existing release artifacts and verify SHA-256 checksums instead of rebuilding.
+- Chrome publication converts the verified ZIP into a CRX using the registered signing key and validates that the key matches the configured extension ID.
 - Store publication rejects prerelease tags before using provider credentials.
 - Each store has separate credentials and a separate protected GitHub Environment.
 - Store submission remains independently approvable.

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 function required(name) {
   const value = process.env[name];
@@ -28,7 +29,10 @@ async function sleep(milliseconds) {
 
 async function main() {
   const packagePath = process.argv[2];
-  if (!packagePath || !fs.existsSync(packagePath)) throw new Error('A valid Chrome package path is required');
+  if (!packagePath || !fs.existsSync(packagePath)) throw new Error('A valid Chrome CRX package path is required');
+  if (path.extname(packagePath).toLowerCase() !== '.crx') {
+    throw new Error('Verified CRX Uploads are enabled: the Chrome package must be a signed .crx file');
+  }
 
   const publisherId = required('CHROME_PUBLISHER_ID');
   const extensionId = required('CHROME_EXTENSION_ID');
@@ -58,12 +62,14 @@ async function main() {
       method: 'POST',
       headers: {
         Authorization: authorization,
-        'Content-Type': 'application/zip'
+        'Content-Type': 'application/x-chrome-extension',
+        'X-Goog-Upload-Protocol': 'raw',
+        'X-Goog-Upload-File-Name': path.basename(packagePath)
       },
       body: fs.readFileSync(packagePath)
     }
   );
-  let uploadData = await parseResponse(uploadResponse, 'Chrome package upload');
+  let uploadData = await parseResponse(uploadResponse, 'Chrome CRX package upload');
 
   for (let attempt = 0; uploadData.uploadState === 'UPLOAD_IN_PROGRESS' && attempt < 60; attempt += 1) {
     await sleep(10_000);
@@ -76,7 +82,7 @@ async function main() {
   if (uploadData.uploadState !== 'SUCCEEDED') {
     throw new Error(`Chrome upload did not succeed: ${JSON.stringify(uploadData)}`);
   }
-  console.log('Chrome package upload succeeded.');
+  console.log('Chrome verified CRX upload succeeded.');
 
   if (!submit) {
     console.log('Chrome publication was not requested; the uploaded draft remains unpublished.');

--- a/tests/store-release-policy.test.js
+++ b/tests/store-release-policy.test.js
@@ -5,11 +5,29 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
-const workflowPath = path.resolve(__dirname, '..', '.github', 'workflows', 'publish-store.yml');
+const root = path.resolve(__dirname, '..');
+const workflowPath = path.join(root, '.github', 'workflows', 'publish-store.yml');
+const chromePublisherPath = path.join(root, 'scripts', 'publish-chrome.js');
 
 test('store publication rejects prerelease tags', () => {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
   assert.match(workflow, /Store publication requires a stable numeric tag/);
   assert.match(workflow, /\^v\[0-9\]\+\(\\\.\[0-9\]\+\)\{0,3\}\$/);
   assert.doesNotMatch(workflow, /\(-\[0-9A-Za-z\.\-\]\+\)\?/);
+});
+
+test('Chrome publication requires a verified CRX and isolated signing key', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+  const publisher = fs.readFileSync(chromePublisherPath, 'utf8');
+
+  assert.match(workflow, /CHROME_CRX_PRIVATE_KEY_B64/);
+  assert.match(workflow, /google-chrome --pack-extension=/);
+  assert.match(workflow, /The CRX signing key does not match CHROME_EXTENSION_ID/);
+  assert.match(workflow, /openssl pkey -in/);
+  assert.match(workflow, /trap cleanup EXIT/);
+  assert.match(publisher, /must be a signed \.crx file/);
+  assert.match(publisher, /'X-Goog-Upload-Protocol': 'raw'/);
+  assert.match(publisher, /'X-Goog-Upload-File-Name': path\.basename\(packagePath\)/);
+  assert.match(publisher, /'Content-Type': 'application\/x-chrome-extension'/);
+  assert.doesNotMatch(publisher, /'Content-Type': 'application\/zip'/);
 });


### PR DESCRIPTION
## Summary

- signs the checksummed Chrome release ZIP into a CRX inside the protected `store-chrome` environment
- requires a separate `CHROME_CRX_PRIVATE_KEY_B64` environment secret
- validates the RSA key and derives its Chrome extension ID before signing
- fails if the signing key does not match `CHROME_EXTENSION_ID`
- uploads the CRX using Google's required raw-upload headers
- removes temporary key material after signing
- adds regression tests and exact setup documentation

## Security model

The registered CRX private key remains separate from the Google publisher account. Automated publication requires access to the protected GitHub environment and explicit reviewer approval. An encrypted offline backup remains mandatory.

## Manual prerequisite

Add `CHROME_CRX_PRIVATE_KEY_B64` to the `store-chrome` environment using the base64 encoding of the exact private key whose public key was registered in Chrome Web Store Verified CRX Uploads. Never place the key in repository files, issues, variables, or chat messages.