### PR TITLE
feat: ship opt-in cross-browser integrity preview

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,8 +1,8 @@
 # Privacy policy
 
-Last updated: 22 July 2026
+Last updated: 23 July 2026
 
-MDPI Filter is designed to identify MDPI-related content and, when research-integrity lookups are enabled, check scholarly DOI identifiers for formal post-publication updates.
+MDPI Filter is designed to identify MDPI-related content and can optionally check scholarly DOI identifiers for formal post-publication updates.
 
 ## Data processed locally
 
@@ -16,24 +16,24 @@ This processing occurs inside the browser. Article text, bibliography text, sear
 
 ## Data sent for integrity lookups
 
-When **Check DOI integrity status with Crossref** is enabled, the extension sends normalized DOI identifiers to the Crossref REST API solely to retrieve scholarly metadata and post-publication update relationships, including retractions, expressions of concern, corrections, reinstatements, withdrawals/removals, and related notices.
+Research-integrity lookups are **off by default**. When the user explicitly enables **Check article and reference DOIs**, the extension sends normalized DOI identifiers to the Crossref REST API solely to retrieve scholarly metadata and post-publication update relationships, including retractions, expressions of concern, corrections, reinstatements, withdrawals/removals, and related notices.
 
 Requests:
 
 - omit cookies and other credentials;
 - use a no-referrer policy;
 - do not include the webpage address, article text, citation text, account identifiers, or analytics identifiers;
-- are limited and rate-spaced to respect Crossref's public service.
+- are limited and rate-spaced to no more than four request starts per second.
 
 Crossref operates independently and its own privacy terms apply to requests it receives.
 
 ## Storage
 
-The extension stores user settings in browser synchronization storage. Lookup responses are cached only in the extension service worker's memory and may disappear when the worker stops. The extension does not create an analytics profile or persistent browsing-history database.
+The extension stores user settings in browser synchronization storage. Lookup responses are cached only in the extension background process's memory and may disappear when it stops. The extension does not create an analytics profile or persistent browsing-history database.
 
 ## User control
 
-Integrity lookups can be disabled at any time from the extension popup. Disabling them stops new DOI requests. Existing MDPI detection continues to work, subject to its separate NCBI lookup preference.
+Integrity lookups can be enabled or disabled at any time from the extension popup. Disabling them cancels active requests and prevents new DOI requests. Existing MDPI detection continues to work, subject to its separate NCBI lookup preference.
 
 ## Coverage and limitations
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extDesc": {
-    "message": "Instantly identify MDPI content. Hide/highlight MDPI papers in literature searches & visually mark their citations in any article.",
+    "message": "Identify MDPI content and optionally check article and reference DOIs for formal post-publication updates.",
     "description": "A short description of the extension's purpose."
   }
-} 
+}

--- a/background.js
+++ b/background.js
@@ -1,22 +1,47 @@
 'use strict';
 
+if (!globalThis.MDPIIntegrity && typeof importScripts === 'function') {
+  importScripts('shared/integrity.js');
+}
+
+const integrityApi = globalThis.MDPIIntegrity;
+if (!integrityApi) throw new Error('Integrity runtime failed to load');
+
+const {
+  STATUS_DEFINITIONS,
+  badgeForSummary,
+  createStartRateLimiter,
+  derivePrimaryStatus,
+  normalizeCrossrefEvents,
+  normalizeDOI,
+  summarizeIntegrityRecords
+} = integrityApi;
+
 const tabData = new Map();
+const legacyBadgeData = new Map();
+const integrityTabData = new Map();
+const integrityCache = new Map();
+const activeIntegrityScans = new Map();
+
 const MAX_REFERENCES_PER_TAB = 500;
 const MAX_REFERENCE_TEXT_LENGTH = 1000;
+const MAX_INTEGRITY_REFERENCES = 250;
+const MAX_INTEGRITY_LOOKUPS_PER_SCAN = 50;
+const CROSSREF_CONCURRENCY = 2;
+const CROSSREF_TIMEOUT_MS = 10000;
+const CROSSREF_CACHE_MS = 24 * 60 * 60 * 1000;
 const SAFE_REFERENCE_ID = /^[A-Za-z0-9_.:-]{1,256}$/;
 const SAFE_COLOR = /^#[0-9A-F]{6}$/i;
+const waitForCrossrefStart = createStartRateLimiter(250);
 
 function normalizeReference(reference) {
   if (!reference || typeof reference !== 'object') return null;
   if (typeof reference.id !== 'string' || !SAFE_REFERENCE_ID.test(reference.id)) return null;
   if (typeof reference.text !== 'string') return null;
-
-  const normalized = {
-    id: reference.id,
-    text: reference.text.slice(0, MAX_REFERENCE_TEXT_LENGTH)
-  };
+  const normalized = { id: reference.id, text: reference.text.slice(0, MAX_REFERENCE_TEXT_LENGTH) };
   if (Number.isFinite(reference.number)) normalized.number = reference.number;
-  if (typeof reference.doi === 'string') normalized.doi = reference.doi.slice(0, 256);
+  const doi = normalizeDOI(reference.doi || '');
+  if (doi) normalized.doi = doi;
   if (typeof reference.listItemDomId === 'string' && SAFE_REFERENCE_ID.test(reference.listItemDomId)) {
     normalized.listItemDomId = reference.listItemDomId;
   }
@@ -35,16 +60,66 @@ function normalizeReferences(references) {
   return Array.from(unique.values());
 }
 
-function setBadge(tabId, count, color = '#E2211C') {
+function normalizeIntegrityInput(data) {
+  const unique = new Map();
+  const pageDoi = normalizeDOI(data?.pageDoi || '');
+  if (pageDoi) {
+    unique.set(pageDoi, { id: 'current-article', kind: 'current-article', number: null, doi: pageDoi, text: 'Current article' });
+  }
+  const references = Array.isArray(data?.references) ? data.references : [];
+  for (const reference of references.slice(0, MAX_INTEGRITY_REFERENCES)) {
+    if (!reference || typeof reference !== 'object') continue;
+    const doi = normalizeDOI(reference.doi || '');
+    if (!doi || unique.has(doi)) continue;
+    const id = typeof reference.id === 'string' && SAFE_REFERENCE_ID.test(reference.id)
+      ? reference.id
+      : `integrity-ref-${unique.size + 1}`;
+    unique.set(doi, {
+      id,
+      kind: 'reference',
+      number: Number.isFinite(reference.number) ? Math.max(1, Math.trunc(reference.number)) : null,
+      doi,
+      text: String(reference.text || '').replace(/\s+/g, ' ').trim().slice(0, MAX_REFERENCE_TEXT_LENGTH)
+    });
+  }
+  return Array.from(unique.values());
+}
+
+function setBadge(tabId, count, color = '#E2211C', title = 'MDPI Filter') {
   if (!Number.isInteger(tabId)) return;
   const numericCount = Number.isFinite(count) ? Math.max(0, Math.min(999, Math.trunc(count))) : 0;
   const safeColor = typeof color === 'string' && SAFE_COLOR.test(color) ? color : '#E2211C';
   chrome.action.setBadgeText({ tabId, text: numericCount ? String(numericCount) : '' });
   chrome.action.setBadgeBackgroundColor({ tabId, color: safeColor });
+  chrome.action.setTitle({ tabId, title: String(title || 'MDPI Filter').slice(0, 200) });
+}
+
+function refreshBadge(tabId) {
+  if (!Number.isInteger(tabId)) return;
+  const integrity = integrityTabData.get(tabId);
+  if (integrity?.summary?.affected > 0) {
+    const badge = badgeForSummary(integrity.summary);
+    setBadge(tabId, badge.count, badge.color, badge.title);
+    return;
+  }
+  const legacy = legacyBadgeData.get(tabId);
+  setBadge(tabId, legacy?.count || 0, legacy?.color || '#E2211C', 'MDPI Filter');
+}
+
+function cancelIntegrityScan(tabId) {
+  const scan = activeIntegrityScans.get(tabId);
+  if (!scan) return;
+  scan.cancelled = true;
+  for (const controller of scan.controllers) controller.abort();
+  scan.controllers.clear();
+  activeIntegrityScans.delete(tabId);
 }
 
 function clearTabData(tabId) {
+  cancelIntegrityScan(tabId);
   tabData.delete(tabId);
+  legacyBadgeData.delete(tabId);
+  integrityTabData.delete(tabId);
   setBadge(tabId, 0);
 }
 
@@ -52,14 +127,123 @@ function storeTabReferences(tabId, references, requestedCount, color) {
   if (!Number.isInteger(tabId)) return [];
   const normalized = normalizeReferences(references);
   tabData.set(tabId, normalized);
-  const count = Number.isFinite(requestedCount) ? requestedCount : normalized.length;
-  setBadge(tabId, count, color);
+  legacyBadgeData.set(tabId, {
+    count: Number.isFinite(requestedCount) ? Math.max(0, Math.trunc(requestedCount)) : normalized.length,
+    color: typeof color === 'string' && SAFE_COLOR.test(color) ? color : '#E2211C'
+  });
+  refreshBadge(tabId);
   return normalized;
 }
 
 async function getActiveTab() {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
   return tabs[0] || null;
+}
+
+async function fetchCrossrefRecord(doi, scan) {
+  const cached = integrityCache.get(doi);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  if (scan.cancelled) return { lookupStatus: 'cancelled', events: [] };
+  await waitForCrossrefStart();
+  if (scan.cancelled) return { lookupStatus: 'cancelled', events: [] };
+
+  const controller = new AbortController();
+  scan.controllers.add(controller);
+  const timeout = setTimeout(() => controller.abort(), CROSSREF_TIMEOUT_MS);
+  try {
+    const response = await fetch(`https://api.crossref.org/works/${encodeURIComponent(doi)}`, {
+      method: 'GET',
+      credentials: 'omit',
+      referrerPolicy: 'no-referrer',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal
+    });
+    if (response.status === 404) {
+      const value = { lookupStatus: 'not-found', events: [] };
+      integrityCache.set(doi, { expiresAt: Date.now() + CROSSREF_CACHE_MS, value });
+      return value;
+    }
+    if (!response.ok) throw new Error(`Crossref returned HTTP ${response.status}`);
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.toLowerCase().includes('application/json')) throw new Error('Crossref returned a non-JSON response');
+    const payload = await response.json();
+    const value = { lookupStatus: 'checked', events: normalizeCrossrefEvents(payload?.message) };
+    integrityCache.set(doi, { expiresAt: Date.now() + CROSSREF_CACHE_MS, value });
+    return value;
+  } catch (error) {
+    if (scan.cancelled || error?.name === 'AbortError') return { lookupStatus: 'cancelled', events: [] };
+    return {
+      lookupStatus: 'failed',
+      events: [],
+      error: error instanceof Error ? error.message.slice(0, 160) : 'Crossref lookup failed'
+    };
+  } finally {
+    clearTimeout(timeout);
+    scan.controllers.delete(controller);
+  }
+}
+
+async function mapWithConcurrency(values, concurrency, worker) {
+  const results = new Array(values.length);
+  let nextIndex = 0;
+  async function run() {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(values[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, run));
+  return results;
+}
+
+async function processIntegrityScan(tabId, data) {
+  if (!Number.isInteger(tabId)) return;
+  cancelIntegrityScan(tabId);
+  const scan = { cancelled: false, controllers: new Set() };
+  activeIntegrityScans.set(tabId, scan);
+  const input = normalizeIntegrityInput(data);
+  const attempted = input.slice(0, MAX_INTEGRITY_LOOKUPS_PER_SCAN);
+  integrityTabData.set(tabId, {
+    state: input.length ? 'loading' : 'ready',
+    provider: 'Crossref + Retraction Watch',
+    totalDiscovered: input.length,
+    attempted: attempted.length,
+    notChecked: Math.max(0, input.length - attempted.length),
+    records: attempted.map(record => ({ ...record, lookupStatus: 'pending', events: [], primaryStatus: null })),
+    summary: summarizeIntegrityRecords([], input.length),
+    updatedAt: new Date().toISOString()
+  });
+  refreshBadge(tabId);
+
+  if (!attempted.length) {
+    activeIntegrityScans.delete(tabId);
+    chrome.runtime.sendMessage({ type: 'integrityReportUpdated', tabId }, () => void chrome.runtime.lastError);
+    return;
+  }
+
+  const records = await mapWithConcurrency(attempted, CROSSREF_CONCURRENCY, async record => {
+    if (scan.cancelled) return { ...record, lookupStatus: 'cancelled', events: [], primaryStatus: null };
+    const lookup = await fetchCrossrefRecord(record.doi, scan);
+    const events = Array.isArray(lookup.events) ? lookup.events : [];
+    return { ...record, lookupStatus: lookup.lookupStatus, error: lookup.error, events, primaryStatus: derivePrimaryStatus(events) };
+  });
+
+  if (scan.cancelled || activeIntegrityScans.get(tabId) !== scan) return;
+  activeIntegrityScans.delete(tabId);
+  const visibleRecords = records.filter(record => record.lookupStatus !== 'cancelled');
+  integrityTabData.set(tabId, {
+    state: 'ready',
+    provider: 'Crossref + Retraction Watch',
+    totalDiscovered: input.length,
+    attempted: attempted.length,
+    notChecked: Math.max(0, input.length - attempted.length),
+    records: visibleRecords,
+    summary: summarizeIntegrityRecords(visibleRecords, input.length),
+    updatedAt: new Date().toISOString()
+  });
+  refreshBadge(tabId);
+  chrome.runtime.sendMessage({ type: 'integrityReportUpdated', tabId }, () => void chrome.runtime.lastError);
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -77,7 +261,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message.action === 'updateBadge') {
     const tabId = sender.tab?.id;
-    if (Number.isInteger(tabId)) setBadge(tabId, Number(message.count), message.color);
+    if (Number.isInteger(tabId)) {
+      legacyBadgeData.set(tabId, { count: Number(message.count) || 0, color: message.color });
+      refreshBadge(tabId);
+    }
     sendResponse({ success: Number.isInteger(tabId) });
     return false;
   }
@@ -87,16 +274,39 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (Number.isInteger(tabId)) {
       const normalized = storeTabReferences(tabId, message.references, message.references?.length, message.color);
       sendResponse({ success: true, count: normalized.length });
-    } else {
-      sendResponse({ success: false });
+    } else sendResponse({ success: false });
+    return false;
+  }
+
+  if (message.type === 'integrityScan') {
+    const tabId = sender.tab?.id;
+    if (Number.isInteger(tabId)) void processIntegrityScan(tabId, message.data || {});
+    sendResponse({ success: Number.isInteger(tabId) });
+    return false;
+  }
+
+  if (message.type === 'integrityScanDisabled') {
+    const tabId = sender.tab?.id;
+    if (Number.isInteger(tabId)) {
+      cancelIntegrityScan(tabId);
+      integrityTabData.delete(tabId);
+      refreshBadge(tabId);
     }
+    sendResponse({ success: Number.isInteger(tabId) });
     return false;
   }
 
   if (message.type === 'getMdpiReferences') {
-    getActiveTab()
-      .then(tab => sendResponse({ references: Number.isInteger(tab?.id) ? (tabData.get(tab.id) || []) : [] }))
+    getActiveTab().then(tab => sendResponse({ references: Number.isInteger(tab?.id) ? (tabData.get(tab.id) || []) : [] }))
       .catch(() => sendResponse({ references: [] }));
+    return true;
+  }
+
+  if (message.type === 'getIntegrityReport') {
+    getActiveTab().then(tab => {
+      const report = Number.isInteger(tab?.id) ? integrityTabData.get(tab.id) : null;
+      sendResponse({ report: report || null, statuses: STATUS_DEFINITIONS });
+    }).catch(() => sendResponse({ report: null, statuses: STATUS_DEFINITIONS }));
     return true;
   }
 
@@ -105,26 +315,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse({ success: false, error: 'invalid-reference-id' });
       return false;
     }
-
-    getActiveTab()
-      .then(tab => {
-        if (!Number.isInteger(tab?.id)) {
-          sendResponse({ success: false, error: 'no-active-tab' });
-          return;
+    getActiveTab().then(tab => {
+      if (!Number.isInteger(tab?.id)) {
+        sendResponse({ success: false, error: 'no-active-tab' });
+        return;
+      }
+      chrome.tabs.sendMessage(tab.id, { type: 'scrollToRefOnPage', refId: message.refId }, response => {
+        if (chrome.runtime.lastError) sendResponse({ success: false, error: 'content-script-unavailable' });
+        else {
+          const status = response?.status;
+          sendResponse({ success: status === 'scrolled' || status === 'expanded-and-scrolled' });
         }
-        chrome.tabs.sendMessage(tab.id, {
-          type: 'scrollToRefOnPage',
-          refId: message.refId
-        }, response => {
-          if (chrome.runtime.lastError) {
-            sendResponse({ success: false, error: 'content-script-unavailable' });
-          } else {
-            const status = response?.status;
-            sendResponse({ success: status === 'scrolled' || status === 'expanded-and-scrolled' });
-          }
-        });
-      })
-      .catch(() => sendResponse({ success: false, error: 'tab-query-failed' }));
+      });
+    }).catch(() => sendResponse({ success: false, error: 'tab-query-failed' }));
     return true;
   }
 
@@ -135,6 +338,4 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === 'loading') clearTabData(tabId);
 });
 
-chrome.tabs.onRemoved.addListener(tabId => {
-  tabData.delete(tabId);
-});
+chrome.tabs.onRemoved.addListener(tabId => clearTabData(tabId));

--- a/background.js
+++ b/background.js
@@ -1,9 +1,6 @@
 'use strict';
 
-if (!globalThis.MDPIIntegrity && typeof importScripts === 'function') {
-  importScripts('shared/integrity.js');
-}
-
+if (!globalThis.MDPIIntegrity && typeof importScripts === 'function') importScripts('shared/integrity.js');
 const integrityApi = globalThis.MDPIIntegrity;
 if (!integrityApi) throw new Error('Integrity runtime failed to load');
 
@@ -63,9 +60,7 @@ function normalizeReferences(references) {
 function normalizeIntegrityInput(data) {
   const unique = new Map();
   const pageDoi = normalizeDOI(data?.pageDoi || '');
-  if (pageDoi) {
-    unique.set(pageDoi, { id: 'current-article', kind: 'current-article', number: null, doi: pageDoi, text: 'Current article' });
-  }
+  if (pageDoi) unique.set(pageDoi, { id: 'current-article', kind: 'current-article', number: null, doi: pageDoi, text: 'Current article' });
   const references = Array.isArray(data?.references) ? data.references : [];
   for (const reference of references.slice(0, MAX_INTEGRITY_REFERENCES)) {
     if (!reference || typeof reference !== 'object') continue;
@@ -140,6 +135,18 @@ async function getActiveTab() {
   return tabs[0] || null;
 }
 
+async function hasIntegrityTransmissionConsent() {
+  const optional = chrome.runtime.getManifest().browser_specific_settings?.gecko?.data_collection_permissions?.optional;
+  if (!Array.isArray(optional) || !optional.includes('websiteContent')) return true;
+  if (!globalThis.browser?.permissions) return false;
+  try {
+    const permissions = await browser.permissions.getAll();
+    return Array.isArray(permissions.data_collection) && permissions.data_collection.includes('websiteContent');
+  } catch {
+    return false;
+  }
+}
+
 async function fetchCrossrefRecord(doi, scan) {
   const cached = integrityCache.get(doi);
   if (cached && cached.expiresAt > Date.now()) return cached.value;
@@ -172,11 +179,7 @@ async function fetchCrossrefRecord(doi, scan) {
     return value;
   } catch (error) {
     if (scan.cancelled || error?.name === 'AbortError') return { lookupStatus: 'cancelled', events: [] };
-    return {
-      lookupStatus: 'failed',
-      events: [],
-      error: error instanceof Error ? error.message.slice(0, 160) : 'Crossref lookup failed'
-    };
+    return { lookupStatus: 'failed', events: [], error: error instanceof Error ? error.message.slice(0, 160) : 'Crossref lookup failed' };
   } finally {
     clearTimeout(timeout);
     scan.controllers.delete(controller);
@@ -188,8 +191,7 @@ async function mapWithConcurrency(values, concurrency, worker) {
   let nextIndex = 0;
   async function run() {
     while (nextIndex < values.length) {
-      const index = nextIndex;
-      nextIndex += 1;
+      const index = nextIndex++;
       results[index] = await worker(values[index], index);
     }
   }
@@ -280,7 +282,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message.type === 'integrityScan') {
     const tabId = sender.tab?.id;
-    if (Number.isInteger(tabId)) void processIntegrityScan(tabId, message.data || {});
+    if (Number.isInteger(tabId)) {
+      void hasIntegrityTransmissionConsent().then(granted => {
+        if (granted) void processIntegrityScan(tabId, message.data || {});
+        else {
+          cancelIntegrityScan(tabId);
+          integrityTabData.delete(tabId);
+          refreshBadge(tabId);
+        }
+      });
+    }
     sendResponse({ success: Number.isInteger(tabId) });
     return false;
   }
@@ -337,5 +348,4 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === 'loading') clearTabData(tabId);
 });
-
 chrome.tabs.onRemoved.addListener(tabId => clearTabData(tabId));

--- a/content/integrity_scanner.js
+++ b/content/integrity_scanner.js
@@ -1,0 +1,163 @@
+'use strict';
+
+;(function initializeIntegrityScanner() {
+  if (window.mdpiIntegrityScannerInjected) return;
+  window.mdpiIntegrityScannerInjected = true;
+
+  const MAX_REFERENCES = 250;
+  const MAX_TEXT_LENGTH = 500;
+  const DOI_PATTERN = /\b10\.\d{4,9}\/[A-Z0-9._;()/:+-]+/gi;
+  let scanTimer = null;
+  let lastFingerprint = '';
+
+  function normalizeDoi(value) {
+    if (typeof value !== 'string') return null;
+    let normalized = value.trim();
+    try {
+      normalized = decodeURIComponent(normalized);
+    } catch {
+      // Keep malformed percent-encoded input unchanged.
+    }
+    normalized = normalized
+      .replace(/^doi\s*:\s*/i, '')
+      .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+      .replace(/[\s\u00A0]+/g, '')
+      .replace(/[),.;:\]}>'"`]+$/g, '')
+      .toLowerCase();
+    return /^10\.\d{4,9}\/[\w.()/:;+-]+$/i.test(normalized) ? normalized : null;
+  }
+
+  function doisFromValue(value) {
+    const dois = [];
+    const seen = new Set();
+    for (const found of String(value || '').matchAll(DOI_PATTERN)) {
+      const doi = normalizeDoi(found[0]);
+      if (doi && !seen.has(doi)) {
+        seen.add(doi);
+        dois.push(doi);
+      }
+    }
+    return dois;
+  }
+
+  function extractDoiFromElement(element) {
+    const candidates = [];
+    for (const attribute of ['data-doi', 'data-article-doi', 'data-reference-doi']) {
+      const value = element.getAttribute?.(attribute);
+      if (value) candidates.push(value);
+    }
+    for (const link of element.querySelectorAll?.('a[href]') || []) {
+      const href = link.getAttribute('href') || '';
+      if (/doi\.org\//i.test(href) || /10\.\d{4,9}\//i.test(href)) candidates.push(href);
+    }
+    candidates.push(element.textContent || '');
+    for (const candidate of candidates) {
+      const doi = doisFromValue(candidate)[0];
+      if (doi) return doi;
+    }
+    return null;
+  }
+
+  function extractCurrentArticleDoi() {
+    const selectors = [
+      'meta[name="citation_doi"]',
+      'meta[name="dc.identifier"]',
+      'meta[name="DC.Identifier"]',
+      'meta[name="doi"]',
+      'meta[property="citation_doi"]'
+    ];
+    for (const selector of selectors) {
+      const value = document.querySelector(selector)?.getAttribute('content') || '';
+      const doi = normalizeDoi(value) || doisFromValue(value)[0];
+      if (doi) return doi;
+    }
+    const canonical = document.querySelector('link[rel="canonical"]')?.getAttribute('href') || '';
+    return doisFromValue(`${canonical} ${document.location.href}`)[0] || null;
+  }
+
+  function referenceNodes() {
+    const configured = window.MDPIFilterReferenceSelectors;
+    if (typeof configured === 'string' && configured.trim()) {
+      try {
+        return Array.from(document.querySelectorAll(configured));
+      } catch {
+        // Fall through to conservative generic selectors.
+      }
+    }
+    return Array.from(document.querySelectorAll(
+      'ol.references > li, ul.references > li, .reference-list li, #references li, [role="doc-bibliography"] li'
+    ));
+  }
+
+  function referenceIdentifier(element, index) {
+    const existing =
+      element.dataset?.mdpiFilterRefId ||
+      element.id ||
+      element.getAttribute?.('data-bib-id') ||
+      element.getAttribute?.('data-reference-id');
+    const normalized = String(existing || '').trim();
+    if (/^[A-Za-z0-9_.:-]{1,256}$/.test(normalized)) return normalized;
+    const generated = `integrity-ref-${index + 1}`;
+    element.setAttribute('data-mdpi-filter-ref-id', generated);
+    return generated;
+  }
+
+  function scanDocument() {
+    chrome.storage.sync.get({ integrityLookupsEnabled: false }, settings => {
+      if (chrome.runtime.lastError) return;
+      if (settings.integrityLookupsEnabled !== true) {
+        chrome.runtime.sendMessage({ type: 'integrityScanDisabled' }, () => void chrome.runtime.lastError);
+        return;
+      }
+
+      const references = [];
+      const seenDois = new Set();
+      const nodes = referenceNodes().slice(0, MAX_REFERENCES);
+      for (let index = 0; index < nodes.length; index += 1) {
+        const element = nodes[index];
+        const doi = extractDoiFromElement(element);
+        if (!doi || seenDois.has(doi)) continue;
+        seenDois.add(doi);
+        references.push({
+          id: referenceIdentifier(element, index),
+          number: index + 1,
+          doi,
+          text: String(element.textContent || '').replace(/\s+/g, ' ').trim().slice(0, MAX_TEXT_LENGTH)
+        });
+      }
+
+      const pageDoi = extractCurrentArticleDoi();
+      const fingerprint = JSON.stringify([pageDoi, references.map(reference => reference.doi)]);
+      if (fingerprint === lastFingerprint) return;
+      lastFingerprint = fingerprint;
+      chrome.runtime.sendMessage({ type: 'integrityScan', data: { pageDoi, references } }, () => void chrome.runtime.lastError);
+    });
+  }
+
+  function scheduleScan(delay = 400) {
+    clearTimeout(scanTimer);
+    scanTimer = setTimeout(scanDocument, delay);
+  }
+
+  chrome.runtime.onMessage.addListener(message => {
+    if (message?.type === 'forceIntegrityRescan') {
+      lastFingerprint = '';
+      scheduleScan(0);
+    }
+  });
+
+  chrome.storage.onChanged.addListener(changes => {
+    if (changes.integrityLookupsEnabled) {
+      lastFingerprint = '';
+      scheduleScan(0);
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => scheduleScan(0), { once: true });
+  } else scheduleScan(0);
+
+  const observer = new MutationObserver(() => scheduleScan(1200));
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+  setTimeout(() => scheduleScan(0), 2500);
+})();

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -1,43 +1,60 @@
-# Chrome Web Store release checklist
+# Multi-browser store release checklist
 
-The `0.1.0` research-integrity preview must not be submitted until every item is evidenced.
+The `0.1.0` research-integrity preview must not receive a stable release tag or be submitted to any browser store until every applicable item is evidenced.
 
 ## Package and provenance
 
-- [ ] Use the ZIP produced by the successful GitHub Actions run for the release commit.
-- [ ] Record the commit SHA, workflow run, artifact checksum, manifest version, and package size.
-- [ ] Verify ZIP integrity and confirm there are no untracked/generated runtime files.
-- [ ] Retain the previous store package and rollback instructions.
+- [ ] Use packages produced by the successful GitHub Actions run for the exact release commit.
+- [ ] Record the commit SHA, workflow run, artifact checksums, manifest versions, and package sizes.
+- [ ] Verify ZIP integrity and confirm there are no untracked or unexpected generated runtime files.
+- [ ] Retain the previous Chrome and Edge store packages and rollback instructions.
+- [ ] Compare the canonical Edge package with the currently published Edge package before replacing the old repository workflow.
 
-## Privacy disclosure
+## Privacy and listing disclosure
 
-- [ ] Publish `PRIVACY.md` at a stable public URL.
-- [ ] Update the Chrome Web Store privacy form to disclose DOI identifiers/website content used for the user-requested integrity feature.
-- [ ] State that DOI identifiers are sent to Crossref solely for scholarly metadata/status lookup.
-- [ ] State that page/article text, full URLs, search queries, browsing history, account identifiers, and analytics identifiers are not sent.
-- [ ] Confirm the declared purpose is single-purpose functionality, not advertising, profiling, or sale.
-- [ ] Verify the store listing and privacy policy use identical descriptions.
+- [ ] Confirm the public Chrome, Edge, Firefox, and Safari privacy-policy URLs load successfully.
+- [ ] Update the Chrome Web Store privacy form to disclose the optional DOI/website-content transmission.
+- [ ] Update the Microsoft Edge listing and privacy declarations with the same description.
+- [ ] Confirm the Firefox listing exposes the privacy policy and Mozilla's optional `websiteContent` consent prompt.
+- [ ] State consistently that only normalized DOI identifiers are sent to Crossref for scholarly metadata and post-publication status lookup.
+- [ ] State consistently that page/article text, citation text, full URLs, search queries, browsing history, cookies, account identifiers, and analytics identifiers are not sent.
+- [ ] Confirm the declared purpose is single-purpose functionality, not advertising, profiling, sale, credit assessment, or unrelated transfer.
 
 ## Runtime evidence
 
-- [ ] Inspect browser network traffic on retraction, concern, correction, reinstatement, duplicate-publication, clean, unresolved, and more-than-50-DOI fixtures.
+Perform the checks in current Chrome, Edge, and Firefox builds. Repeat Safari checks before any App Store submission.
+
+- [ ] With integrity lookups disabled, confirm zero Crossref requests occur, including after navigation and DOM mutations.
+- [ ] Enable lookups and inspect traffic on retraction, concern, correction, reinstatement, duplicate-publication, clean, unresolved, and more-than-50-DOI fixtures.
 - [ ] Confirm every Crossref request contains only the DOI in the endpoint and sends no cookies or referrer.
 - [ ] Confirm request starts remain at or below four per second.
-- [ ] Confirm disabling integrity lookups causes zero Crossref requests.
-- [ ] Confirm deferred, unresolved, and failed counts are displayed and never labeled safe/clear.
-- [ ] Confirm toolbar badge counts affected works once, not notices.
+- [ ] Disable lookups during an active scan and confirm queued and in-flight requests stop.
+- [ ] In Firefox, deny the optional data permission and confirm no Crossref request occurs; grant it and confirm lookups work.
+- [ ] Confirm deferred, unresolved, not-found, and failed records are never labeled safe or clear.
+- [ ] Confirm toolbar badge counts affected works once, not individual notices.
+- [ ] Confirm reinstatement supersedes an older retraction while preserving the event history.
 - [ ] Confirm existing MDPI detection still works when no integrity signal is present.
 
 ## Accessibility and presentation
 
 - [ ] Verify each status has icon, text, and color; color is not the sole signal.
 - [ ] Verify keyboard navigation, focus visibility, screen-reader labels, light mode, and dark mode.
-- [ ] Capture store screenshots showing counters, event chronology/provenance, coverage, and the privacy toggle.
-- [ ] Update release notes with limitations and data-source attribution.
+- [ ] Capture store screenshots showing opt-in controls, counters, event chronology/provenance, and coverage limitations.
+- [ ] Update release notes with limitations, Crossref/Retraction Watch attribution, and the opt-in privacy model.
 
-## Rollout
+## Store sequence
 
-- [ ] Publish to a small staged percentage first.
-- [ ] Monitor only Chrome Web Store aggregate diagnostics; do not add product analytics.
-- [ ] Expand only after checking error reports and false-positive reports.
-- [ ] Stop or roll back if privacy behavior, request load, or status classification differs from the validated artifact.
+- [ ] Create the stable tag only after all checks above pass.
+- [ ] Upload Chrome with `submit=false`; inspect the signed CRX draft and store declarations.
+- [ ] Upload Edge with `submit=false`; inspect the draft and certification notes.
+- [ ] Submit Chrome and Edge only after both drafts match the tested artifacts.
+- [ ] Submit Firefox with `submit=true` only after reviewing the generated source package and listing metadata; AMO has no equivalent useful draft-only step in this workflow.
+- [ ] Keep Safari source-only until Apple signing, device testing, App Store metadata, and review prerequisites are complete.
+- [ ] Keep the dedicated Edge repository available until the canonical Edge update passes certification.
+
+## Rollout and monitoring
+
+- [ ] Use the smallest supported staged rollout for Chrome and Edge.
+- [ ] Monitor only store-provided aggregate diagnostics and user reports; do not add product analytics.
+- [ ] Expand rollout only after checking errors, permission-denial behavior, and false-positive reports.
+- [ ] Stop or roll back if privacy behavior, request load, compatibility, or status classification differs from the validated artifact.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "__MSG_extDesc__",
   "default_locale": "en",
   "permissions": [
@@ -14,8 +14,7 @@
     "extension_pages": "script-src 'self'; object-src 'self'; upgrade-insecure-requests;"
   },
   "background": {
-    "service_worker": "background.js",
-    "type": "module"
+    "service_worker": "background.js"
   },
   "icons": {
     "16": "icons/icon-16.png",
@@ -59,7 +58,8 @@
         "content/reference_id_extractor.js",
         "content/ncbi_api_handler.js",
         "content/content_script.js",
-        "content/secure_message_handler.js"
+        "content/secure_message_handler.js",
+        "content/integrity_scanner.js"
       ],
       "run_at": "document_idle"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdpi-filter-browser-extension",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdpi-filter-browser-extension",
-      "version": "0.0.4",
+      "version": "0.1.0",
       "license": "AGPL-3.0-or-later"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mdpi-filter-browser-extension",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "private": true,
-  "description": "Cross-browser extension that identifies and manages MDPI publications.",
+  "description": "Cross-browser extension for MDPI detection and explainable research-integrity signals.",
   "scripts": {
     "build": "node scripts/build-all.js",
     "build:target": "node scripts/build-target.js",

--- a/platforms/firefox/manifest.json
+++ b/platforms/firefox/manifest.json
@@ -4,6 +4,7 @@
     "service_worker": null,
     "type": null,
     "scripts": [
+      "shared/integrity.js",
       "background.js"
     ]
   },

--- a/platforms/firefox/manifest.json
+++ b/platforms/firefox/manifest.json
@@ -11,7 +11,18 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "mdpi-filter@mdpi-filter.org",
-      "strict_min_version": "128.0"
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": [
+          "none"
+        ],
+        "optional": [
+          "websiteContent"
+        ]
+      }
+    },
+    "gecko_android": {
+      "strict_min_version": "142.0"
     }
   }
 }

--- a/popup.css
+++ b/popup.css
@@ -1,250 +1,219 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --surface: #ffffff;
+  --surface-subtle: #f8fafc;
+  --text: #101828;
+  --muted: #667085;
+  --border: #d0d5dd;
+  --brand: #36406b;
+  --brand-hover: #2a324f;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #101828;
+    --surface-subtle: #1d2939;
+    --text: #f2f4f7;
+    --muted: #98a2b3;
+    --border: #344054;
+    --brand: #98a2d8;
+    --brand-hover: #b6bee8;
+  }
+}
+
+* { box-sizing: border-box; }
+
 body {
   margin: 0;
-  font-family: sans-serif;
-  width: 320px; /* Increased width for references */
-  max-height: 500px; /* Limit popup height */
-  overflow-y: auto; /* Allow scrolling if content exceeds height */
-  background: #f9f9f9;
+  width: 390px;
+  max-height: 620px;
+  overflow-y: auto;
+  background: var(--surface-subtle);
+  color: var(--text);
 }
 
-.container {
-  position: relative;
-  padding-top: 8px;
-}
+.container { padding: 16px; }
 
-.container {
-  padding: 16px;
-}
-
-h1 {
-  font-size: 20px;       /* Slightly bigger */
-  margin: 0 0 8px 0;     /* No top margin, small bottom */
-  color: #36406B;
-  text-align: left;
-}
-
-p {
-  font-size: 14px;
-  margin-bottom: 12px;
-}
-
-.radio {
+.popup-header,
+.section-heading-row,
+.integrity-item-heading,
+.setting-item,
+.radio,
+.checkbox-label {
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
-  font-size: 14px;
 }
 
-.radio input {
-  margin-right: 8px;
+.popup-header,
+.section-heading-row,
+.integrity-item-heading { justify-content: space-between; gap: 12px; }
+
+h1 {
+  margin: 0;
+  color: var(--brand);
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.product-subtitle,
+.coverage-text,
+.signal-disclaimer,
+.integrity-item p,
+small { color: var(--muted); }
+
+.product-subtitle { margin: 3px 0 0; font-size: 12px; }
+
+h2 {
+  margin: 0 0 8px;
+  color: var(--brand);
+  font-size: 15px;
 }
 
 button {
   width: 100%;
-  padding: 8px;
-  font-size: 14px;
-  background: #36406B;
-  color: white;
-  border: none;
-  border-radius: 4px;
+  padding: 9px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--brand);
+  color: #fff;
   cursor: pointer;
-  margin-top: 8px; /* Add some margin between elements */
+  font: inherit;
+  font-size: 13px;
 }
 
-button:hover {
-  background: #2a324f;
+button:hover { background: var(--brand-hover); }
+button:focus-visible, [tabindex="0"]:focus-visible, input:focus-visible {
+  outline: 3px solid #84adff;
+  outline-offset: 2px;
 }
 
-/* Style for the secondary report button */
-button.secondary {
-  background-color: #6c757d; /* Grey background */
+.icon-button,
+.text-button {
+  width: auto;
+  background: transparent;
+  color: var(--brand);
 }
 
-button.secondary:hover {
-  background-color: #5a6268; /* Darker grey on hover */
-}
+.icon-button { width: 32px; height: 32px; padding: 5px; }
+.text-button { padding: 4px 6px; font-size: 12px; }
+.icon-button:hover,
+.text-button:hover { background: color-mix(in srgb, var(--brand) 10%, transparent); }
+button.secondary { background: #475467; }
+button.secondary:hover { background: #344054; }
 
-#status {
-  margin-top: 8px;
-  font-size: 12px;
-  color: #226622;
-  min-height: 1em; /* Prevent layout shift when empty */
-}
-
-/* Style for the separator */
 .separator {
-  border: none;
-  border-top: 1px solid #ccc;
-  margin: 16px 0; /* Increased margin */
+  margin: 14px 0;
+  border: 0;
+  border-top: 1px solid var(--border);
 }
 
-/* --- Reference List Styles --- */
-h2 {
-  font-size: 16px;
-  margin-bottom: 8px;
-  color: #36406B;
+.settings-panel {
+  display: none;
+  margin: 12px 0 16px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 4px 14px rgb(16 24 40 / 10%);
+}
+.settings-panel.open { display: block; }
+.settings-title { margin: 8px 0 10px; font-size: 13px; font-weight: 650; color: var(--brand); }
+.radio, .checkbox-label { align-items: flex-start; gap: 8px; margin: 9px 0; font-size: 13px; }
+.radio input, .checkbox-label input { margin: 2px 0 0; flex: 0 0 auto; }
+.checkbox-label span { display: grid; gap: 3px; line-height: 1.35; }
+.checkbox-label small { font-size: 11px; line-height: 1.35; }
+.setting-item { gap: 10px; margin: 10px 0; font-size: 13px; }
+.color-picker-input { margin-left: auto; width: 44px; height: 28px; padding: 0; border: 1px solid var(--border); border-radius: 5px; }
+#status { min-height: 16px; margin-top: 8px; color: #067647; font-size: 12px; }
+
+.integrity-section {
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--surface);
+}
+.coverage-text { margin: 0; font-size: 11px; line-height: 1.4; }
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 12px;
+}
+.status-card {
+  min-height: 70px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: 1px 7px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--signal-color, var(--border));
+  border-radius: 7px;
+  background: var(--surface-subtle);
+  opacity: .72;
+}
+.status-card.has-signal { opacity: 1; box-shadow: 0 0 0 1px color-mix(in srgb, var(--signal-color) 25%, transparent); }
+.status-card .status-icon { grid-row: 1 / 3; font-weight: 800; font-size: 20px; color: var(--signal-color); }
+.status-card strong { font-size: 18px; line-height: 1; }
+.status-card > span:last-child { font-size: 10px; color: var(--muted); line-height: 1.1; }
+.status-retracted { --signal-color: #b42318; }
+.status-concern { --signal-color: #b54708; }
+.status-corrected { --signal-color: #175cd3; }
+.status-reinstated { --signal-color: #067647; }
+.status-duplicate { --signal-color: #6941c6; }
+.status-withdrawn { --signal-color: #475467; }
+.signal-disclaimer { margin: 10px 0 8px; font-size: 10px; line-height: 1.35; }
+
+.integrity-list,
+#referencesList { list-style: none; margin: 0; padding: 0; }
+.integrity-list { max-height: 245px; overflow-y: auto; }
+.integrity-item { padding: 9px 0; border-top: 1px solid var(--border); cursor: default; }
+.integrity-item[data-ref-id] { cursor: pointer; }
+.integrity-item[data-ref-id]:hover { background: color-mix(in srgb, var(--brand) 5%, transparent); }
+.integrity-item-heading { align-items: baseline; }
+.integrity-item-heading strong { font-size: 12px; }
+.integrity-item-heading code { max-width: 230px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 10px; }
+.integrity-item p { margin: 5px 0; font-size: 11px; line-height: 1.35; }
+.signal-chips { display: flex; flex-wrap: wrap; gap: 5px; }
+.signal-chip {
+  padding: 3px 6px;
+  border: 1px solid var(--signal-color);
+  border-radius: 999px;
+  color: var(--signal-color);
+  background: color-mix(in srgb, var(--signal-color) 8%, transparent);
+  font-size: 10px;
+  font-weight: 650;
 }
 
 #referencesListContainer {
-  max-height: 200px; /* Limit height of the list container */
-  overflow-y: auto;   /* Allow scrolling within the list */
-  border: 1px solid #ddd;
-  background-color: #fff;
-  padding: 4px 0; /* Padding top/bottom */
-  border-radius: 4px;
-  margin-bottom: 12px; /* Space below the list */
+  max-height: 180px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
 }
-
-#referencesList {
-  list-style: none; /* Remove default bullets */
-  padding: 0 12px; /* Padding left/right inside the list */
-  margin: 0;
-}
-
+#referencesList { padding: 0 11px; }
 #referencesList li {
-  font-size: 12px;
-  padding: 6px 0;
-  border-bottom: 1px solid #eee;
-  line-height: 1.4;
-  cursor: pointer; /* Make it look clickable */
-  transition: background-color 0.15s ease-in-out; /* Smooth hover effect */
-}
-
-#referencesList li:hover {
-  background-color: #f0f0f0; /* Slight background change on hover */
-}
-
-#referencesList li:last-child {
-  border-bottom: none; /* Remove border from last item */
-}
-
-#referencesList li .ref-number {
-  font-weight: bold;
-  color: #555;
-  margin-right: 4px;
-}
-
-#referencesList li .ref-text {
-  color: #333;
-}
-
-/* Remove or comment out .ref-link styles as it's no longer used */
-/*
-#referencesList li .ref-link {
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
   font-size: 11px;
-  color: #007bff;
-  text-decoration: none;
-  margin-left: 4px;
+  line-height: 1.4;
+  cursor: pointer;
 }
-#referencesList li .ref-link:hover {
-  text-decoration: underline;
-}
-*/
-
-/* Style for placeholder/error messages */
-#referencesList li.placeholder,
-#referencesList li.error {
-  font-style: italic;
-  color: #777;
+#referencesList li:last-child { border-bottom: 0; }
+#referencesList li:hover { background: color-mix(in srgb, var(--brand) 5%, transparent); }
+.ref-number { font-weight: 700; color: var(--muted); }
+.ref-text { color: var(--text); }
+.placeholder, .error {
+  padding: 12px !important;
+  border: 0 !important;
+  color: var(--muted);
   text-align: center;
-  padding: 10px;
-  border-bottom: none;
+  font-size: 11px;
+  font-style: italic;
+  cursor: default !important;
 }
-#referencesList li.error {
-    color: #dc3545; /* Red for errors */
-}
-/* --- End Reference List Styles --- */
-
-/* Settings Icon */
-#settingsIcon {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: transparent;
-  border: none;
-  padding: 2px;
-  cursor: pointer;
-  z-index: 10;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-#settingsIcon svg {
-  display: block;
-}
-
-/* Settings Panel */
-.settings-panel {
-  display: none;
-  background: #fff;
-  border: 1px solid #ddd;
-  border-radius: 6px;
-  padding: 14px 12px 8px 12px;
-  margin-bottom: 14px;
-  margin-top: 2px;
-  box-shadow: 0 2px 10px rgba(54,64,107,0.07);
-  position: relative;
-}
-
-.settings-panel.open {
-  display: block;
-}
-
-.settings-title {
-  font-size: 14px;
-  font-weight: 500;
-  margin-bottom: 10px;
-  color: #36406B;
-  margin-top: 10px; /* Add some space above new section title */
-}
-
-/* Styles for new settings in popup */
-.setting-item {
-  display: flex;
-  align-items: center;
-  margin-bottom: 10px; /* Increased margin */
-  font-size: 14px;
-}
-
-.setting-item .color-label { /* Class for the "Highlight Color:" text */
-  margin-right: 8px;
-  flex-shrink: 0; /* Prevent shrinking if space is tight */
-}
-
-.checkbox-label { /* For aligning checkbox and its text */
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  flex-grow: 1; /* Allow text to take available space */
-}
-
-.checkbox-label input[type="checkbox"] {
-  margin-right: 8px; /* Increased margin */
-  flex-shrink: 0;
-}
-
-.checkbox-label span {
-  line-height: 1.3; /* Improve readability */
-}
-
-.color-picker-input {
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 0; /* Remove padding if it affects appearance */
-  height: 28px;
-  width: 45px; /* Adjust as needed */
-  cursor: pointer;
-  background-color: #fff; /* Ensure background for color swatch */
-  margin-left: auto; /* Push color picker to the right if in flex container */
-}
-
-/* Warning text style */
-.setting-warning {
-  color: red;
-  font-size: 0.85em;
-  margin-left: 8px;
-}
-/* End Styles for new settings */
+.error { color: #b42318; }

--- a/popup.html
+++ b/popup.html
@@ -2,100 +2,84 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>MDPI Filter</title>
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
-  <div class="container">
-    <!-- Title -->
-    <h1>MDPI Filter</h1>
+  <main class="container">
+    <header class="popup-header">
+      <div>
+        <h1>MDPI Filter</h1>
+        <p class="product-subtitle">Research-integrity preview</p>
+      </div>
+      <button id="settingsIcon" class="icon-button" title="Settings" aria-label="Open settings" aria-expanded="false">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="3"></circle>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33A1.65 1.65 0 0 0 14 20.83V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15 1.65 1.65 0 0 0 3.17 14H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 8.92 4 1.65 1.65 0 0 0 10 2.49V2a2 2 0 1 1 4 0v.09A1.65 1.65 0 0 0 15 3.6a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.32 8 1.65 1.65 0 0 0 20.83 9H21a2 2 0 1 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15z"></path>
+        </svg>
+      </button>
+    </header>
 
-    <!-- Settings Icon (gear matching MDPI style) -->
-    <button id="settingsIcon" title="Settings" aria-label="Settings">
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none"
-           stroke="#36406B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="3"></circle>
-        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06
-                 a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21
-                 a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51
-                 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83
-                 l.06-.06a1.65 1.65 0 0 0 .33-1.82
-                 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09
-                 a1.65 1.65 0 0 0 1.51-1
-                 1.65 1.65 0 0 0-.33-1.82l-.06-.06
-                 a2 2 0 1 1 2.83-2.83l.06.06
-                 a1.65 1.65 0 0 0 1.82.33H9
-                 a1.65 1.65 0 0 0 1-1.51V3
-                 a2 2 0 1 1 4 0v.09
-                 a1.65 1.65 0 0 0 1 1.51
-                 1.65 1.65 0 0 0 1.82-.33l.06-.06
-                 a2 2 0 1 1 2.83 2.83l-.06.06
-                 a1.65 1.65 0 0 0-.33 1.82V9
-                 a1.65 1.65 0 0 0 1.51 1H21
-                 a2 2 0 1 1 0 4h-.09
-                 a1.65 1.65 0 0 0-1.51 1z"/>
-      </svg>
-    </button>
+    <section id="settingsPanel" class="settings-panel" aria-label="Extension settings">
+      <p class="settings-title">Search-result handling</p>
+      <label class="radio"><input type="radio" name="mode" value="highlight"><span>Highlight MDPI results</span></label>
+      <label class="radio"><input type="radio" name="mode" value="hide"><span>Hide MDPI results</span></label>
 
-    <!-- Settings Panel (hidden by default) -->
-    <div id="settingsPanel" class="settings-panel">
-      <p class="settings-title">Select how MDPI results are handled on search sites:</p>
-      <label class="radio">
-        <input type="radio" name="mode" value="highlight">
-        <span>Highlight MDPI results</span>
-      </label>
-      <label class="radio">
-        <input type="radio" name="mode" value="hide">
-        <span>Hide MDPI results</span>
-      </label>
       <hr class="separator">
-      <!-- New Settings for Potential MDPI Highlighting -->
-      <p class="settings-title">Potential MDPI Site Highlighting (Google Search Only):</p>
-      <div class="setting-item">
-        <label class="checkbox-label" for="highlightPotentialMdpi">
-          <input type="checkbox" id="highlightPotentialMdpi">
-          <span>Highlight potential sites</span>
-        </label>
-      </div>
-      <div class="setting-item">
-        <label for="potentialMdpiColor" class="color-label">Highlight Color:</label>
-        <input type="color" id="potentialMdpiColor" class="color-picker-input">
-      </div>
-      <!-- Advanced Settings -->
-      <hr class="separator">
-      <p class="settings-title">Advanced Settings</p>
-      <div class="setting-item">
-        <label class="checkbox-label" for="loggingEnabled">
-          <input type="checkbox" id="loggingEnabled" name="loggingEnabled">
-          <span>Enable Extension Logging</span>
-        </label>
-      </div>
-      <div class="setting-item">
-        <label class="checkbox-label" for="ncbiApiEnabledPopup">
-          <input type="checkbox" id="ncbiApiEnabledPopup">
-          <span>Enable NCBI API lookups</span>
-          <span class="setting-warning">Disabling reduces accuracy, leading to missed or incorrect highlights.</span>
-        </label>
-      </div>
-       <!-- End New Settings -->
-       <!-- Save button and status moved here -->
-       <button id="save">Save</button>
-      <div id="status"></div>
-    </div>
+      <p class="settings-title">Research-integrity lookups</p>
+      <label class="checkbox-label" for="integrityLookupsEnabled">
+        <input type="checkbox" id="integrityLookupsEnabled">
+        <span>
+          Check article and reference DOIs
+          <small>Off by default. When enabled, only DOI identifiers are sent to Crossref; page text and browsing history are not transmitted.</small>
+        </span>
+      </label>
 
-    <!-- Section for MDPI References -->
-    <h2><span id="referencesCount">Loading</span> MDPI References Found:</h2>
-    <div id="referencesListContainer">
-      <ul id="referencesList">
-        <!-- References will be injected here -->
-        <li id="referencesPlaceholder" class="placeholder">Loading references...</li>
-      </ul>
-    </div>
-    <!-- End Section -->
+      <hr class="separator">
+      <p class="settings-title">Potential MDPI sites</p>
+      <label class="checkbox-label" for="highlightPotentialMdpi"><input type="checkbox" id="highlightPotentialMdpi"><span>Highlight potential sites on Google</span></label>
+      <div class="setting-item"><label for="potentialMdpiColor" class="color-label">Highlight color</label><input type="color" id="potentialMdpiColor" class="color-picker-input"></div>
+
+      <hr class="separator">
+      <p class="settings-title">Advanced</p>
+      <label class="checkbox-label" for="loggingEnabled"><input type="checkbox" id="loggingEnabled" name="loggingEnabled"><span>Enable extension logging</span></label>
+      <label class="checkbox-label" for="ncbiApiEnabledPopup">
+        <input type="checkbox" id="ncbiApiEnabledPopup">
+        <span>Enable NCBI lookups<small>Disabling this reduces MDPI detection accuracy.</small></span>
+      </label>
+      <button id="save">Save settings</button>
+      <div id="status" role="status" aria-live="polite"></div>
+    </section>
+
+    <section class="integrity-section" aria-labelledby="integrityHeading">
+      <div class="section-heading-row">
+        <div><h2 id="integrityHeading">Integrity signals</h2><p id="integrityCoverage" class="coverage-text">Integrity lookups are disabled.</p></div>
+        <button id="rescanIntegrity" class="text-button" type="button">Rescan</button>
+      </div>
+
+      <div id="integrityStatusGrid" class="status-grid" aria-label="Integrity signal counts">
+        <div class="status-card status-retracted" data-status="retracted"><span class="status-icon" aria-hidden="true">×</span><strong id="countRetracted">0</strong><span>Retracted</span></div>
+        <div class="status-card status-concern" data-status="expression-of-concern"><span class="status-icon" aria-hidden="true">!</span><strong id="countConcern">0</strong><span>Concern</span></div>
+        <div class="status-card status-corrected" data-status="corrected"><span class="status-icon" aria-hidden="true">✎</span><strong id="countCorrected">0</strong><span>Corrected</span></div>
+        <div class="status-card status-reinstated" data-status="reinstated"><span class="status-icon" aria-hidden="true">↩</span><strong id="countReinstated">0</strong><span>Reinstated</span></div>
+        <div class="status-card status-duplicate" data-status="duplicate-publication"><span class="status-icon" aria-hidden="true">≡</span><strong id="countDuplicate">0</strong><span>Duplicate</span></div>
+        <div class="status-card status-withdrawn" data-status="withdrawn"><span class="status-icon" aria-hidden="true">–</span><strong id="countWithdrawn">0</strong><span>Withdrawn</span></div>
+      </div>
+
+      <p class="signal-disclaimer">No signal means only that none was found in the checked sources—not that a work is safe or reliable.</p>
+      <ul id="integrityList" class="integrity-list"><li id="integrityPlaceholder" class="placeholder">Enable lookups in settings to check DOI status metadata.</li></ul>
+    </section>
 
     <hr class="separator">
-    <button id="reportIssue" class="secondary">Report Filter Issue</button>
-  </div>
+    <section aria-labelledby="mdpiReferencesHeading">
+      <h2 id="mdpiReferencesHeading"><span id="referencesCount">Loading</span> MDPI references</h2>
+      <div id="referencesListContainer"><ul id="referencesList"><li id="referencesPlaceholder" class="placeholder">Loading references…</li></ul></div>
+    </section>
+
+    <hr class="separator">
+    <button id="reportIssue" class="secondary">Report a detection issue</button>
+  </main>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -31,6 +31,27 @@ document.addEventListener('DOMContentLoaded', () => {
     if (timeout) setTimeout(() => { el.status.textContent = ''; }, timeout);
   }
 
+  function usesFirefoxDataConsent() {
+    const optional = chrome.runtime.getManifest().browser_specific_settings?.gecko?.data_collection_permissions?.optional;
+    return Array.isArray(optional) && optional.includes('websiteContent') && Boolean(globalThis.browser?.permissions);
+  }
+
+  async function hasFirefoxDataConsent() {
+    if (!usesFirefoxDataConsent()) return true;
+    const permissions = await browser.permissions.getAll();
+    return Array.isArray(permissions.data_collection) && permissions.data_collection.includes('websiteContent');
+  }
+
+  async function requestFirefoxDataConsent() {
+    if (!usesFirefoxDataConsent()) return true;
+    return browser.permissions.request({ data_collection: ['websiteContent'] });
+  }
+
+  async function removeFirefoxDataConsent() {
+    if (!usesFirefoxDataConsent()) return true;
+    return browser.permissions.remove({ data_collection: ['websiteContent'] });
+  }
+
   function setCounts(counts = {}) {
     for (const [status, id] of Object.entries(countIds)) {
       const value = Number(counts[status]) || 0;
@@ -81,9 +102,15 @@ document.addEventListener('DOMContentLoaded', () => {
     el.color.value = settings.potentialMdpiHighlightColor || '#FFFF99';
     el.logging.checked = Boolean(settings.loggingEnabled);
     el.ncbi.checked = settings.ncbiApiEnabled !== false;
-    el.integrity.checked = settings.integrityLookupsEnabled === true;
-    if (el.integrity.checked) loadIntegrity();
-    else renderDisabled();
+    void (async () => {
+      const permitted = await hasFirefoxDataConsent().catch(() => false);
+      el.integrity.checked = settings.integrityLookupsEnabled === true && permitted;
+      if (settings.integrityLookupsEnabled === true && !permitted) {
+        chrome.storage.sync.set({ integrityLookupsEnabled: false });
+      }
+      if (el.integrity.checked) loadIntegrity();
+      else renderDisabled();
+    })();
   });
 
   function requestRescan() {
@@ -97,20 +124,34 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   el.save.addEventListener('click', () => {
-    if (!el.ncbi.checked && !confirm('Disabling NCBI lookups reduces MDPI detection accuracy. Continue?')) return;
-    chrome.storage.sync.set({
-      mode: radios.find(radio => radio.checked)?.value || 'highlight',
-      highlightPotentialMdpiSites: el.potential.checked,
-      potentialMdpiHighlightColor: el.color.value || '#FFFF99',
-      loggingEnabled: el.logging.checked,
-      ncbiApiEnabled: el.ncbi.checked,
-      integrityLookupsEnabled: el.integrity.checked
-    }, () => {
-      if (chrome.runtime.lastError) return setStatus('Error saving settings.');
-      setStatus('Settings saved.');
-      if (el.integrity.checked) requestRescan();
-      else renderDisabled();
-    });
+    void (async () => {
+      if (!el.ncbi.checked && !confirm('Disabling NCBI lookups reduces MDPI detection accuracy. Continue?')) return;
+      if (el.integrity.checked) {
+        const granted = await requestFirefoxDataConsent().catch(() => false);
+        if (!granted) {
+          el.integrity.checked = false;
+          renderDisabled();
+          setStatus('Firefox data permission was not granted.');
+          return;
+        }
+      } else {
+        await removeFirefoxDataConsent().catch(() => false);
+      }
+
+      chrome.storage.sync.set({
+        mode: radios.find(radio => radio.checked)?.value || 'highlight',
+        highlightPotentialMdpiSites: el.potential.checked,
+        potentialMdpiHighlightColor: el.color.value || '#FFFF99',
+        loggingEnabled: el.logging.checked,
+        ncbiApiEnabled: el.ncbi.checked,
+        integrityLookupsEnabled: el.integrity.checked
+      }, () => {
+        if (chrome.runtime.lastError) return setStatus('Error saving settings.');
+        setStatus('Settings saved.');
+        if (el.integrity.checked) requestRescan();
+        else renderDisabled();
+      });
+    })();
   });
 
   el.rescan.addEventListener('click', () => {

--- a/popup.js
+++ b/popup.js
@@ -1,34 +1,69 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const radios = Array.from(document.querySelectorAll('input[name="mode"]'));
-  const saveBtn = document.getElementById('save');
-  const status = document.getElementById('status');
-  const reportBtn = document.getElementById('reportIssue');
-  const referencesList = document.getElementById('referencesList');
-  const referencesPlaceholder = document.getElementById('referencesPlaceholder');
-  const referencesCountSpan = document.getElementById('referencesCount');
-  const settingsIcon = document.getElementById('settingsIcon');
-  const settingsPanel = document.getElementById('settingsPanel');
-  const highlightPotentialCheckbox = document.getElementById('highlightPotentialMdpi');
-  const potentialColorInput = document.getElementById('potentialMdpiColor');
-  const loggingEnabledCheckbox = document.getElementById('loggingEnabled');
-  const ncbiApiCheckbox = document.getElementById('ncbiApiEnabledPopup');
-
-  const setStatus = (message, timeoutMs = 3500) => {
-    status.textContent = message;
-    if (timeoutMs > 0) setTimeout(() => { status.textContent = ''; }, timeoutMs);
+  const $ = id => document.getElementById(id);
+  const radios = [...document.querySelectorAll('input[name="mode"]')];
+  const el = {
+    save: $('save'), status: $('status'), report: $('reportIssue'), settings: $('settingsIcon'), panel: $('settingsPanel'),
+    potential: $('highlightPotentialMdpi'), color: $('potentialMdpiColor'), logging: $('loggingEnabled'), ncbi: $('ncbiApiEnabledPopup'), integrity: $('integrityLookupsEnabled'),
+    refs: $('referencesList'), refsPlaceholder: $('referencesPlaceholder'), refsCount: $('referencesCount'),
+    integrityList: $('integrityList'), integrityPlaceholder: $('integrityPlaceholder'), coverage: $('integrityCoverage'), rescan: $('rescanIntegrity')
+  };
+  const countIds = {
+    retracted: 'countRetracted',
+    'expression-of-concern': 'countConcern',
+    corrected: 'countCorrected',
+    reinstated: 'countReinstated',
+    'duplicate-publication': 'countDuplicate',
+    withdrawn: 'countWithdrawn'
+  };
+  const fallbackStatuses = {
+    retracted: { label: 'Retracted', icon: '×', color: '#B42318' },
+    'expression-of-concern': { label: 'Expression of concern', icon: '!', color: '#B54708' },
+    corrected: { label: 'Corrected', icon: '✎', color: '#175CD3' },
+    reinstated: { label: 'Reinstated', icon: '↩', color: '#067647' },
+    'duplicate-publication': { label: 'Duplicate publication', icon: '≡', color: '#6941C6' },
+    withdrawn: { label: 'Withdrawn or removed', icon: '–', color: '#475467' }
   };
 
-  settingsIcon.addEventListener('click', () => {
-    settingsPanel.classList.toggle('open');
-  });
+  function setStatus(message, timeout = 3500) {
+    el.status.textContent = message;
+    if (timeout) setTimeout(() => { el.status.textContent = ''; }, timeout);
+  }
 
+  function setCounts(counts = {}) {
+    for (const [status, id] of Object.entries(countIds)) {
+      const value = Number(counts[status]) || 0;
+      const node = $(id);
+      node.textContent = String(value);
+      const card = node.closest('.status-card');
+      card.classList.toggle('has-signal', value > 0);
+      card.setAttribute('aria-label', `${fallbackStatuses[status].label}: ${value}`);
+    }
+  }
+
+  function clearIntegrityItems() {
+    el.integrityList.querySelectorAll('li:not(#integrityPlaceholder)').forEach(node => node.remove());
+  }
+
+  function renderDisabled() {
+    setCounts();
+    clearIntegrityItems();
+    el.coverage.textContent = 'Integrity lookups are disabled.';
+    el.integrityPlaceholder.textContent = 'Enable lookups in settings to check DOI status metadata.';
+    el.integrityPlaceholder.style.display = 'block';
+  }
+
+  renderDisabled();
+
+  el.settings.addEventListener('click', () => {
+    const open = el.panel.classList.toggle('open');
+    el.settings.setAttribute('aria-expanded', String(open));
+  });
   document.addEventListener('mousedown', event => {
-    if (settingsPanel.classList.contains('open') &&
-        !settingsPanel.contains(event.target) &&
-        !settingsIcon.contains(event.target)) {
-      settingsPanel.classList.remove('open');
+    if (el.panel.classList.contains('open') && !el.panel.contains(event.target) && !el.settings.contains(event.target)) {
+      el.panel.classList.remove('open');
+      el.settings.setAttribute('aria-expanded', 'false');
     }
   });
 
@@ -37,205 +72,212 @@ document.addEventListener('DOMContentLoaded', () => {
     highlightPotentialMdpiSites: false,
     potentialMdpiHighlightColor: '#FFFF99',
     loggingEnabled: false,
-    ncbiApiEnabled: true
+    ncbiApiEnabled: true,
+    integrityLookupsEnabled: false
   }, settings => {
-    if (chrome.runtime.lastError) {
-      setStatus('Error loading settings.');
-      return;
-    }
+    if (chrome.runtime.lastError) return setStatus('Error loading settings.');
     radios.forEach(radio => { radio.checked = radio.value === settings.mode; });
-    highlightPotentialCheckbox.checked = Boolean(settings.highlightPotentialMdpiSites);
-    potentialColorInput.value = settings.potentialMdpiHighlightColor || '#FFFF99';
-    loggingEnabledCheckbox.checked = Boolean(settings.loggingEnabled);
-    ncbiApiCheckbox.checked = settings.ncbiApiEnabled !== false;
+    el.potential.checked = Boolean(settings.highlightPotentialMdpiSites);
+    el.color.value = settings.potentialMdpiHighlightColor || '#FFFF99';
+    el.logging.checked = Boolean(settings.loggingEnabled);
+    el.ncbi.checked = settings.ncbiApiEnabled !== false;
+    el.integrity.checked = settings.integrityLookupsEnabled === true;
+    if (el.integrity.checked) loadIntegrity();
+    else renderDisabled();
   });
 
-  saveBtn.addEventListener('click', () => {
-    const selectedMode = radios.find(radio => radio.checked)?.value || 'highlight';
-    const ncbiEnabled = ncbiApiCheckbox.checked;
-    if (!ncbiEnabled && !confirm('Disabling NCBI API lookups reduces detection accuracy. Continue?')) {
-      return;
-    }
-
-    chrome.storage.sync.set({
-      mode: selectedMode,
-      highlightPotentialMdpiSites: highlightPotentialCheckbox.checked,
-      potentialMdpiHighlightColor: potentialColorInput.value || '#FFFF99',
-      loggingEnabled: loggingEnabledCheckbox.checked,
-      ncbiApiEnabled: ncbiEnabled
-    }, () => {
-      if (chrome.runtime.lastError) {
-        setStatus('Error saving settings.');
-      } else {
-        setStatus('Settings saved.');
-      }
-    });
-  });
-
-  reportBtn.addEventListener('click', () => {
+  function requestRescan() {
     chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
-      const activeUrl = tabs[0]?.url;
-      if (!activeUrl) {
-        setStatus('Could not read the current page address.');
-        return;
-      }
-
-      let reportedAddress;
-      try {
-        const parsed = new URL(activeUrl);
-        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-          throw new Error('Unsupported page protocol');
-        }
-        // Deliberately exclude query parameters and fragments. They often contain
-        // search terms, document identifiers, session values, or access tokens.
-        reportedAddress = `${parsed.origin}${parsed.pathname}`;
-      } catch {
-        setStatus('Issue reports are available only for web pages.');
-        return;
-      }
-
-      const repository = 'mdpi-filter/mdpi-filter-chrome';
-      const manifest = chrome.runtime.getManifest();
-      const currentMode = radios.find(radio => radio.checked)?.value || 'N/A';
-      const title = encodeURIComponent(`Filter issue on ${new URL(reportedAddress).hostname}`);
-      const body = encodeURIComponent(`**Report a filter issue**
-
-Before submitting, please remove any information you do not want to publish publicly.
-
-**Webpage address (query parameters and fragments omitted):**
-${reportedAddress}
-
-**Describe the filter issue:**
-[Was an MDPI result missed, or was a non-MDPI result incorrectly flagged?]
-
----
-**Troubleshooting information:**
-- Extension: ${manifest.name}
-- Version: ${manifest.version}
-- Filter mode: ${currentMode}
-- Browser: ${navigator.userAgent}
-
-**Screenshots or additional context:**
-[Optional]
-`);
-
-      chrome.tabs.create({
-        url: `https://github.com/${repository}/issues/new?title=${title}&body=${body}`
+      if (!Number.isInteger(tabs[0]?.id)) return;
+      chrome.tabs.sendMessage(tabs[0].id, { type: 'forceIntegrityRescan' }, () => {
+        void chrome.runtime.lastError;
+        setTimeout(loadIntegrity, 300);
       });
     });
+  }
+
+  el.save.addEventListener('click', () => {
+    if (!el.ncbi.checked && !confirm('Disabling NCBI lookups reduces MDPI detection accuracy. Continue?')) return;
+    chrome.storage.sync.set({
+      mode: radios.find(radio => radio.checked)?.value || 'highlight',
+      highlightPotentialMdpiSites: el.potential.checked,
+      potentialMdpiHighlightColor: el.color.value || '#FFFF99',
+      loggingEnabled: el.logging.checked,
+      ncbiApiEnabled: el.ncbi.checked,
+      integrityLookupsEnabled: el.integrity.checked
+    }, () => {
+      if (chrome.runtime.lastError) return setStatus('Error saving settings.');
+      setStatus('Settings saved.');
+      if (el.integrity.checked) requestRescan();
+      else renderDisabled();
+    });
   });
 
-  function displayReferences(references, isLoading = false, errorMessage = '') {
-    referencesList.querySelectorAll('li:not(#referencesPlaceholder)').forEach(item => item.remove());
+  el.rescan.addEventListener('click', () => {
+    if (!el.integrity.checked) return setStatus('Enable integrity lookups in settings first.');
+    el.coverage.textContent = 'Rescanning article references…';
+    requestRescan();
+  });
 
-    if (isLoading) {
-      referencesCountSpan.textContent = 'Loading';
-      referencesPlaceholder.textContent = 'Loading references...';
-      referencesPlaceholder.classList.remove('error');
-      referencesPlaceholder.style.display = 'block';
+  el.report.addEventListener('click', () => {
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      try {
+        const parsed = new URL(tabs[0]?.url || '');
+        if (!/^https?:$/.test(parsed.protocol)) throw new Error();
+        const address = `${parsed.origin}${parsed.pathname}`;
+        const manifest = chrome.runtime.getManifest();
+        const title = encodeURIComponent(`Detection issue on ${parsed.hostname}`);
+        const body = encodeURIComponent(`**Report a detection issue**\n\nBefore submitting, remove information you do not want public.\n\n**Webpage address (query and fragment omitted):**\n${address}\n\n**Problem:**\n[Missed, incorrect, or wrong integrity status]\n\n---\n- Extension: ${manifest.name}\n- Version: ${manifest.version}\n- Integrity lookups: ${el.integrity.checked ? 'enabled' : 'disabled'}\n- Browser: ${navigator.userAgent}`);
+        chrome.tabs.create({ url: `https://github.com/mdpi-filter/mdpi-filter-chrome/issues/new?title=${title}&body=${body}` });
+      } catch {
+        setStatus('Issue reports are available only for web pages.');
+      }
+    });
+  });
+
+  function scrollToReference(refId) {
+    chrome.runtime.sendMessage({ type: 'scrollToRef', refId }, response => {
+      if (chrome.runtime.lastError || !response?.success) setStatus('Could not locate that reference.');
+    });
+  }
+
+  for (const list of [el.refs, el.integrityList]) {
+    list.addEventListener('click', event => {
+      const item = event.target.closest('li[data-ref-id]');
+      if (item) scrollToReference(item.dataset.refId);
+    });
+  }
+  el.integrityList.addEventListener('keydown', event => {
+    if (!['Enter', ' '].includes(event.key)) return;
+    const item = event.target.closest('li[data-ref-id]');
+    if (item) {
+      event.preventDefault();
+      scrollToReference(item.dataset.refId);
+    }
+  });
+
+  function renderReferences(references, loading = false, error = '') {
+    el.refs.querySelectorAll('li:not(#referencesPlaceholder)').forEach(node => node.remove());
+    if (loading || error || !references?.length) {
+      el.refsCount.textContent = loading ? 'Loading' : 'No';
+      el.refsPlaceholder.textContent = error || (loading ? 'Loading references…' : 'No MDPI references detected.');
+      el.refsPlaceholder.style.display = 'block';
       return;
     }
-
-    if (errorMessage) {
-      referencesCountSpan.textContent = 'No';
-      referencesPlaceholder.textContent = errorMessage;
-      referencesPlaceholder.classList.add('error');
-      referencesPlaceholder.style.display = 'block';
-      return;
-    }
-
     const unique = new Map();
-    for (const ref of Array.isArray(references) ? references : []) {
-      if (!ref || typeof ref !== 'object' || typeof ref.id !== 'string' || typeof ref.text !== 'string') continue;
-      const key = (ref.doi || ref.text).replace(/\s+/g, ' ').trim().toLowerCase();
-      if (key && !unique.has(key)) unique.set(key, ref);
-    }
-
-    const validReferences = Array.from(unique.values());
-    referencesCountSpan.textContent = validReferences.length ? String(validReferences.length) : 'No';
-    referencesPlaceholder.classList.remove('error');
-
-    if (!validReferences.length) {
-      referencesPlaceholder.textContent = 'No MDPI references detected on this page.';
-      referencesPlaceholder.style.display = 'block';
-      return;
-    }
-
-    referencesPlaceholder.style.display = 'none';
-    for (const ref of validReferences) {
+    for (const ref of references) if (ref?.id && ref?.text) unique.set((ref.doi || ref.text).toLowerCase(), ref);
+    el.refsCount.textContent = String(unique.size);
+    el.refsPlaceholder.style.display = 'none';
+    for (const ref of unique.values()) {
       const item = document.createElement('li');
       item.dataset.refId = ref.id;
-      item.title = 'Click to scroll to reference';
-
-      if (ref.number) {
-        const number = document.createElement('span');
-        number.className = 'ref-number';
-        number.textContent = `${String(ref.number)}. `;
-        item.appendChild(number);
-      }
-
+      const number = document.createElement('span');
+      number.className = 'ref-number';
+      number.textContent = ref.number ? `${ref.number}. ` : '';
       const text = document.createElement('span');
       text.className = 'ref-text';
       text.textContent = ref.text;
-      item.appendChild(text);
-      referencesList.appendChild(item);
+      item.append(number, text);
+      el.refs.appendChild(item);
     }
   }
 
-  referencesList.addEventListener('click', event => {
-    const item = event.target.closest('li[data-ref-id]');
-    if (!item) return;
-
-    chrome.runtime.sendMessage({ type: 'scrollToRef', refId: item.dataset.refId }, response => {
-      if (chrome.runtime.lastError || !response?.success) {
-        setStatus('Could not locate that reference on the page.');
-      }
-    });
-  });
-
-  function loadReferences(attempt = 0, requestedRefresh = false) {
-    if (attempt === 0) displayReferences([], true);
-
+  function loadReferences(attempt = 0) {
+    if (!attempt) renderReferences([], true);
     chrome.runtime.sendMessage({ type: 'getMdpiReferences' }, response => {
-      if (chrome.runtime.lastError) {
-        displayReferences([], false, 'Error loading references.');
-        return;
-      }
-
+      if (chrome.runtime.lastError) return renderReferences([], false, 'Error loading references.');
       const references = Array.isArray(response?.references) ? response.references : [];
-      if (references.length) {
-        displayReferences(references);
+      if (references.length || attempt >= 3) return renderReferences(references);
+      setTimeout(() => loadReferences(attempt + 1), 300);
+    });
+  }
+
+  function chip(event, statuses) {
+    const definition = statuses[event.status] || fallbackStatuses[event.status] || {};
+    const node = document.createElement('span');
+    node.className = 'signal-chip';
+    node.style.setProperty('--signal-color', definition.color || '#475467');
+    node.textContent = `${definition.icon || '•'} ${definition.label || event.status}`;
+    node.title = [
+      event.date && `Date: ${event.date.slice(0, 10)}`,
+      event.source && `Source: ${event.source}`,
+      event.noticeDoi && `Notice DOI: ${event.noticeDoi}`
+    ].filter(Boolean).join('\n');
+    return node;
+  }
+
+  function renderIntegrity(report, statuses = fallbackStatuses) {
+    clearIntegrityItems();
+    if (!report) {
+      setCounts();
+      el.coverage.textContent = 'Waiting for identifiable DOI references…';
+      el.integrityPlaceholder.textContent = 'No DOI-bearing article or references detected yet.';
+      el.integrityPlaceholder.style.display = 'block';
+      return;
+    }
+    setCounts(report.summary?.counts);
+    if (report.state === 'loading') {
+      el.coverage.textContent = `Checking ${report.attempted || 0} of ${report.totalDiscovered || 0} discovered DOIs…`;
+      el.integrityPlaceholder.textContent = 'Looking up post-publication updates…';
+      el.integrityPlaceholder.style.display = 'block';
+      return;
+    }
+    const summary = report.summary || {};
+    const coverage = [`${summary.checked || 0} checked`];
+    if (report.notChecked) coverage.push(`${report.notChecked} deferred by page limit`);
+    if (summary.failed) coverage.push(`${summary.failed} unresolved`);
+    coverage.push(report.provider || 'Crossref');
+    el.coverage.textContent = coverage.join(' · ');
+    const affected = (report.records || []).filter(record => record.primaryStatus);
+    if (!affected.length) {
+      el.integrityPlaceholder.textContent = 'No known integrity signals were found in checked records.';
+      el.integrityPlaceholder.style.display = 'block';
+      return;
+    }
+    el.integrityPlaceholder.style.display = 'none';
+    for (const record of affected) {
+      const item = document.createElement('li');
+      item.className = 'integrity-item';
+      if (record.kind === 'reference' && record.id) {
+        item.dataset.refId = record.id;
+        item.tabIndex = 0;
+      }
+      const heading = document.createElement('div');
+      heading.className = 'integrity-item-heading';
+      const label = document.createElement('strong');
+      label.textContent = record.kind === 'current-article' ? 'Current article' : `Reference ${record.number || ''}`.trim();
+      const doi = document.createElement('code');
+      doi.textContent = record.doi;
+      heading.append(label, doi);
+      item.appendChild(heading);
+      if (record.text && record.kind !== 'current-article') {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = record.text;
+        item.appendChild(paragraph);
+      }
+      const chips = document.createElement('div');
+      chips.className = 'signal-chips';
+      for (const event of record.events || []) chips.appendChild(chip(event, statuses));
+      item.appendChild(chips);
+      el.integrityList.appendChild(item);
+    }
+  }
+
+  function loadIntegrity(attempt = 0) {
+    if (!el.integrity.checked) return renderDisabled();
+    chrome.runtime.sendMessage({ type: 'getIntegrityReport' }, response => {
+      if (chrome.runtime.lastError) {
+        el.coverage.textContent = 'Could not load integrity results.';
         return;
       }
-
-      if (attempt < 3) {
-        setTimeout(() => loadReferences(attempt + 1, requestedRefresh), 300);
-        return;
-      }
-
-      if (!requestedRefresh) {
-        chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
-          const tabId = tabs[0]?.id;
-          if (!tabId) {
-            displayReferences([]);
-            return;
-          }
-          chrome.tabs.sendMessage(tabId, { type: 'forceResendMdpiReferences' }, () => {
-            void chrome.runtime.lastError;
-            setTimeout(() => loadReferences(0, true), 350);
-          });
-        });
-        return;
-      }
-
-      displayReferences([]);
+      renderIntegrity(response?.report || null, response?.statuses || fallbackStatuses);
+      if (response?.report?.state === 'loading' && attempt < 20) setTimeout(() => loadIntegrity(attempt + 1), 500);
     });
   }
 
   chrome.runtime.onMessage.addListener(message => {
-    if (message?.action === 'updateReferences' && Array.isArray(message.references)) {
-      displayReferences(message.references);
-    }
+    if (message?.action === 'updateReferences' && Array.isArray(message.references)) renderReferences(message.references);
+    if (message?.type === 'integrityReportUpdated' && el.integrity.checked) loadIntegrity();
   });
 
   loadReferences();

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -30,6 +30,7 @@ if ((manifest.externally_connectable?.matches || []).length > 0) fail('externall
 
 const referencedFiles = new Set();
 if (manifest.background?.service_worker) referencedFiles.add(manifest.background.service_worker);
+for (const backgroundScript of manifest.background?.scripts || []) referencedFiles.add(backgroundScript);
 if (manifest.action?.default_popup) referencedFiles.add(manifest.action.default_popup);
 if (manifest.options_page) referencedFiles.add(manifest.options_page);
 for (const contentScript of manifest.content_scripts || []) {
@@ -45,6 +46,7 @@ for (const relativePath of referencedFiles) {
   if (!fs.existsSync(path.join(root, relativePath))) fail(`manifest references missing file: ${relativePath}`);
 }
 
+if (!fs.existsSync(path.join(root, 'shared', 'integrity.js'))) fail('shared integrity normalization module is missing');
 if (fs.existsSync(path.join(root, 'content', 'dompurify.min.js'))) {
   fail('vendored DOMPurify must not be reintroduced into the text-only runtime');
 }
@@ -65,9 +67,7 @@ const dangerousPatterns = [
 function verifyJavaScript(absolutePath) {
   const relativePath = path.relative(root, absolutePath);
   const syntaxCheck = spawnSync(process.execPath, ['--check', absolutePath], { encoding: 'utf8' });
-  if (syntaxCheck.status !== 0) {
-    fail(`JavaScript syntax error in ${relativePath}: ${syntaxCheck.stderr.trim()}`);
-  }
+  if (syntaxCheck.status !== 0) fail(`JavaScript syntax error in ${relativePath}: ${syntaxCheck.stderr.trim()}`);
   if (absolutePath === __filename) return;
   const source = fs.readFileSync(absolutePath, 'utf8');
   for (const { pattern, label } of dangerousPatterns) {
@@ -89,9 +89,7 @@ function verifyWorkflow(absolutePath) {
   for (const match of actionUses) {
     const reference = match[1];
     if (reference.startsWith('./') || reference.startsWith('docker://')) continue;
-    if (!/@[0-9a-f]{40}$/i.test(reference)) {
-      fail(`GitHub Action is not pinned to a full commit SHA in ${relativePath}: ${reference}`);
-    }
+    if (!/@[0-9a-f]{40}$/i.test(reference)) fail(`GitHub Action is not pinned to a full commit SHA in ${relativePath}: ${reference}`);
   }
   if (/NCBI_(?:TOOL_NAME|API_EMAIL)_SECRET/.test(source)) {
     fail(`release workflow embeds unnecessary NCBI secrets in ${relativePath}`);

--- a/shared/integrity.js
+++ b/shared/integrity.js
@@ -1,0 +1,214 @@
+'use strict';
+
+;(function exposeIntegrityModule(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  root.MDPIIntegrity = api;
+})(typeof globalThis === 'object' ? globalThis : this, () => {
+  const STATUS_DEFINITIONS = Object.freeze({
+    retracted: Object.freeze({
+      key: 'retracted', label: 'Retracted', shortLabel: 'Retracted', icon: '×', color: '#B42318', severity: 100
+    }),
+    'expression-of-concern': Object.freeze({
+      key: 'expression-of-concern', label: 'Expression of concern', shortLabel: 'Concern', icon: '!', color: '#B54708', severity: 80
+    }),
+    withdrawn: Object.freeze({
+      key: 'withdrawn', label: 'Withdrawn or removed', shortLabel: 'Withdrawn', icon: '–', color: '#475467', severity: 70
+    }),
+    'duplicate-publication': Object.freeze({
+      key: 'duplicate-publication', label: 'Duplicate publication', shortLabel: 'Duplicate', icon: '≡', color: '#6941C6', severity: 60
+    }),
+    corrected: Object.freeze({
+      key: 'corrected', label: 'Corrected', shortLabel: 'Corrected', icon: '✎', color: '#175CD3', severity: 40
+    }),
+    reinstated: Object.freeze({
+      key: 'reinstated', label: 'Reinstated', shortLabel: 'Reinstated', icon: '↩', color: '#067647', severity: 30
+    })
+  });
+
+  const TYPE_MAP = new Map([
+    ['retraction', 'retracted'], ['retracted', 'retracted'], ['partial_retraction', 'retracted'], ['partialretraction', 'retracted'],
+    ['expression_of_concern', 'expression-of-concern'], ['expressionofconcern', 'expression-of-concern'], ['concern', 'expression-of-concern'],
+    ['withdrawal', 'withdrawn'], ['withdrawn', 'withdrawn'], ['removal', 'withdrawn'], ['removed', 'withdrawn'],
+    ['correction', 'corrected'], ['corrected', 'corrected'], ['corrigendum', 'corrected'], ['erratum', 'corrected'],
+    ['addendum', 'corrected'], ['clarification', 'corrected'], ['reinstatement', 'reinstated'], ['reinstated', 'reinstated'],
+    ['retraction_reversal', 'reinstated'], ['reversal', 'reinstated'], ['duplicate_publication', 'duplicate-publication'],
+    ['duplicatepublication', 'duplicate-publication'], ['duplication', 'duplicate-publication']
+  ]);
+
+  function normalizedToken(value) {
+    return String(value || '').trim().toLowerCase().replace(/[\s-]+/g, '_').replace(/[^a-z0-9_]/g, '');
+  }
+
+  function normalizeDOI(value) {
+    if (typeof value !== 'string') return null;
+    let normalized = value.trim();
+    try {
+      normalized = decodeURIComponent(normalized);
+    } catch {
+      // Keep malformed percent-encoded input unchanged.
+    }
+    normalized = normalized
+      .replace(/^doi\s*:\s*/i, '')
+      .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+      .replace(/[\s\u00A0]+/g, '')
+      .replace(/[),.;:\]}>'"`]+$/g, '')
+      .toLowerCase();
+    return /^10\.\d{4,9}\/[\w.()/:;+-]+$/i.test(normalized) ? normalized : null;
+  }
+
+  function normalizeUpdateType(type, label = '') {
+    const direct = TYPE_MAP.get(normalizedToken(type));
+    if (direct) return direct;
+    const fromLabel = TYPE_MAP.get(normalizedToken(label));
+    if (fromLabel) return fromLabel;
+    const combined = `${type || ''} ${label || ''}`.toLowerCase();
+    if (/duplicate|redundant publication/.test(combined)) return 'duplicate-publication';
+    if (/reinstate|reversal/.test(combined)) return 'reinstated';
+    if (/expression.*concern/.test(combined)) return 'expression-of-concern';
+    if (/partial.*retract|retract/.test(combined)) return 'retracted';
+    if (/withdraw|remov/.test(combined)) return 'withdrawn';
+    if (/correct|corrig|errat|addend|clarif/.test(combined)) return 'corrected';
+    return null;
+  }
+
+  function eventTimestamp(update) {
+    const explicit = Number(update?.updated?.timestamp);
+    if (Number.isFinite(explicit) && explicit > 0) return explicit;
+    for (const value of [update?.updated?.['date-time'], update?.date]) {
+      const parsed = Date.parse(value || '');
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return 0;
+  }
+
+  function eventDate(update, timestamp) {
+    const explicit = update?.updated?.['date-time'] || update?.date;
+    if (typeof explicit === 'string' && explicit.trim()) return explicit;
+    return timestamp ? new Date(timestamp).toISOString() : null;
+  }
+
+  function normalizeCrossrefEvents(message) {
+    if (!message || typeof message !== 'object') return [];
+    const updates = Array.isArray(message['updated-by']) ? message['updated-by'].slice(0, 100) : [];
+    const events = [];
+    const seen = new Set();
+    for (const update of updates) {
+      if (!update || typeof update !== 'object') continue;
+      const status = normalizeUpdateType(update.type, update.label);
+      if (!status) continue;
+      const noticeDoi = normalizeDOI(update.DOI || update.doi || '');
+      const timestamp = eventTimestamp(update);
+      const source = String(update.source || 'publisher').trim().toLowerCase();
+      const recordId = update['record-id'] ?? update.recordId ?? null;
+      const key = [status, noticeDoi || '', timestamp || '', source, recordId || ''].join('|');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      events.push({
+        status,
+        label: STATUS_DEFINITIONS[status].label,
+        type: String(update.type || '').trim() || status,
+        noticeDoi,
+        source,
+        recordId,
+        date: eventDate(update, timestamp),
+        timestamp
+      });
+    }
+    return events.sort((a, b) => {
+      if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp;
+      return STATUS_DEFINITIONS[b.status].severity - STATUS_DEFINITIONS[a.status].severity;
+    });
+  }
+
+  function derivePrimaryStatus(events) {
+    const list = Array.isArray(events) ? events : [];
+    if (!list.length) return null;
+    let latestRetraction = -1;
+    let latestReinstatement = -1;
+    let latestConcern = -1;
+    let hasCorrection = false;
+    let hasDuplicate = false;
+    let hasWithdrawal = false;
+    for (const event of list) {
+      const timestamp = Number.isFinite(event?.timestamp) ? event.timestamp : 0;
+      if (event?.status === 'retracted') latestRetraction = Math.max(latestRetraction, timestamp);
+      else if (event?.status === 'reinstated') latestReinstatement = Math.max(latestReinstatement, timestamp);
+      else if (event?.status === 'expression-of-concern') latestConcern = Math.max(latestConcern, timestamp);
+      else if (event?.status === 'corrected') hasCorrection = true;
+      else if (event?.status === 'duplicate-publication') hasDuplicate = true;
+      else if (event?.status === 'withdrawn') hasWithdrawal = true;
+    }
+    if (latestRetraction >= 0 && latestRetraction > latestReinstatement) return 'retracted';
+    if (latestConcern >= 0 && latestConcern > latestRetraction && latestConcern > latestReinstatement) return 'expression-of-concern';
+    if (latestReinstatement >= 0 && latestReinstatement >= latestRetraction) return 'reinstated';
+    if (hasWithdrawal) return 'withdrawn';
+    if (hasDuplicate) return 'duplicate-publication';
+    if (hasCorrection) return 'corrected';
+    return null;
+  }
+
+  function summarizeIntegrityRecords(records, totalRequested = 0) {
+    const normalizedRecords = Array.isArray(records) ? records : [];
+    const counts = Object.fromEntries(Object.keys(STATUS_DEFINITIONS).map(key => [key, 0]));
+    let checked = 0;
+    let failed = 0;
+    let affected = 0;
+    let primaryStatus = null;
+    for (const record of normalizedRecords) {
+      if (record?.lookupStatus === 'checked') checked += 1;
+      else if (record?.lookupStatus === 'failed' || record?.lookupStatus === 'not-found') failed += 1;
+      const statuses = new Set((record?.events || []).map(event => event.status).filter(Boolean));
+      for (const status of statuses) if (Object.hasOwn(counts, status)) counts[status] += 1;
+      if (record?.primaryStatus) {
+        affected += 1;
+        if (!primaryStatus || STATUS_DEFINITIONS[record.primaryStatus].severity > STATUS_DEFINITIONS[primaryStatus].severity) {
+          primaryStatus = record.primaryStatus;
+        }
+      }
+    }
+    return {
+      total: Math.max(Number(totalRequested) || 0, normalizedRecords.length), checked, failed, affected, counts, primaryStatus
+    };
+  }
+
+  function badgeForSummary(summary) {
+    if (!summary?.affected || !summary.primaryStatus) {
+      return { count: 0, color: '#667085', title: 'No known integrity signals' };
+    }
+    const definition = STATUS_DEFINITIONS[summary.primaryStatus];
+    return {
+      count: Math.min(999, Math.max(0, Number(summary.affected) || 0)),
+      color: definition.color,
+      title: `${summary.affected} reference${summary.affected === 1 ? '' : 's'} with known integrity signals`
+    };
+  }
+
+  function createStartRateLimiter(intervalMs = 250, now = () => Date.now(), sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))) {
+    if (!Number.isFinite(intervalMs) || intervalMs < 0) throw new TypeError('intervalMs must be a non-negative number');
+    let nextStartAt = 0;
+    let queue = Promise.resolve();
+    return function waitForStartSlot() {
+      const operation = queue.then(async () => {
+        const current = Number(now());
+        const scheduled = Math.max(current, nextStartAt);
+        nextStartAt = scheduled + intervalMs;
+        if (scheduled > current) await sleep(scheduled - current);
+        return scheduled;
+      });
+      queue = operation.catch(() => undefined);
+      return operation;
+    };
+  }
+
+  return Object.freeze({
+    STATUS_DEFINITIONS,
+    badgeForSummary,
+    createStartRateLimiter,
+    derivePrimaryStatus,
+    normalizeCrossrefEvents,
+    normalizeDOI,
+    normalizeUpdateType,
+    summarizeIntegrityRecords
+  });
+});

--- a/store/chrome/listing.json
+++ b/store/chrome/listing.json
@@ -1,6 +1,6 @@
 {
   "name": "MDPI Filter",
-  "summary": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections.",
+  "summary": "Identify MDPI publications and optionally check article and reference DOIs for formal post-publication updates.",
   "homepage": "https://mdpi-filter.pages.dev/",
-  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/chrome"
+  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/chrome/"
 }

--- a/store/edge/listing.json
+++ b/store/edge/listing.json
@@ -1,6 +1,6 @@
 {
   "name": "MDPI Filter",
-  "summary": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections.",
+  "summary": "Identify MDPI publications and optionally check article and reference DOIs for formal post-publication updates.",
   "homepage": "https://mdpi-filter.pages.dev/",
-  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/edge"
+  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/edge/"
 }

--- a/store/firefox/amo-metadata.json
+++ b/store/firefox/amo-metadata.json
@@ -1,6 +1,6 @@
 {
   "summary": {
-    "en-US": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections."
+    "en-US": "Identify MDPI publications and optionally check article and reference DOIs for formal post-publication updates."
   },
   "categories": [
     "other"
@@ -10,6 +10,6 @@
   },
   "version": {
     "license": "AGPL-3.0-only",
-    "approval_notes": "The submitted package is generated from the public repository without minification, bundling, remote code, or runtime npm dependencies."
+    "approval_notes": "The submitted package is generated from the public repository without minification, bundling, remote code, or runtime npm dependencies. Research-integrity lookups are off by default. If the user explicitly enables them and grants Firefox's optional websiteContent data permission, only normalized DOI identifiers are sent to the Crossref REST API. Page URLs, page or citation text, cookies, account identifiers, and referrers are not sent. Requests are limited to no more than four starts per second and active requests are cancelled when lookups are disabled or navigation begins. Privacy policy: https://mdpi-filter.pages.dev/privacy/firefox/"
   }
 }

--- a/store/safari/listing.json
+++ b/store/safari/listing.json
@@ -1,6 +1,6 @@
 {
   "name": "MDPI Filter",
-  "summary": "Identify MDPI publications in searches, references, cited-by lists, and similar-article sections.",
+  "summary": "Identify MDPI publications and optionally check article and reference DOIs for formal post-publication updates.",
   "homepage": "https://mdpi-filter.pages.dev/",
-  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/safari"
+  "privacyPolicy": "https://mdpi-filter.pages.dev/privacy/safari/"
 }

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.resolve(__dirname, '..');
+const {
+  STATUS_DEFINITIONS,
+  badgeForSummary,
+  createStartRateLimiter,
+  derivePrimaryStatus,
+  normalizeCrossrefEvents,
+  normalizeDOI,
+  normalizeUpdateType,
+  summarizeIntegrityRecords
+} = require('../shared/integrity.js');
+
+test('DOIs are normalized without accepting arbitrary URLs', () => {
+  assert.equal(normalizeDOI(' https://doi.org/10.1000/ABC.123. '), '10.1000/abc.123');
+  assert.equal(normalizeDOI('doi:10.3390/nu4091171'), '10.3390/nu4091171');
+  assert.equal(normalizeDOI('https://example.org/not-a-doi'), null);
+  assert.equal(normalizeDOI('10.1/no'), null);
+});
+
+test('Crossref update labels map to stable statuses', () => {
+  assert.equal(normalizeUpdateType('expression_of_concern'), 'expression-of-concern');
+  assert.equal(normalizeUpdateType('corrigendum'), 'corrected');
+  assert.equal(normalizeUpdateType('', 'Reinstatement'), 'reinstated');
+  assert.equal(normalizeUpdateType('', 'Duplicate publication'), 'duplicate-publication');
+});
+
+test('only updated-by relationships classify the queried work', () => {
+  assert.deepEqual(normalizeCrossrefEvents({
+    DOI: '10.1000/retraction-notice',
+    'update-to': [{ DOI: '10.1000/original-paper', type: 'retraction' }]
+  }), []);
+
+  const events = normalizeCrossrefEvents({
+    'updated-by': [{
+      DOI: '10.1000/notice',
+      type: 'retraction',
+      source: 'retraction-watch',
+      'record-id': 42,
+      updated: { 'date-time': '2025-02-01T00:00:00Z' }
+    }]
+  });
+  assert.equal(events[0].status, 'retracted');
+  assert.equal(events[0].recordId, 42);
+  assert.equal(events[0].noticeDoi, '10.1000/notice');
+});
+
+test('reinstatement supersedes an older retraction without deleting history', () => {
+  assert.equal(derivePrimaryStatus([
+    { status: 'retracted', timestamp: 10 },
+    { status: 'reinstated', timestamp: 20 },
+    { status: 'corrected', timestamp: 30 }
+  ]), 'reinstated');
+});
+
+test('summary counts affected works once per status and drives badge severity', () => {
+  const summary = summarizeIntegrityRecords([
+    {
+      lookupStatus: 'checked',
+      primaryStatus: 'retracted',
+      events: [{ status: 'expression-of-concern' }, { status: 'retracted' }, { status: 'retracted' }]
+    },
+    { lookupStatus: 'checked', primaryStatus: 'corrected', events: [{ status: 'corrected' }] },
+    { lookupStatus: 'failed', primaryStatus: null, events: [] }
+  ], 3);
+  assert.equal(summary.checked, 2);
+  assert.equal(summary.failed, 1);
+  assert.equal(summary.affected, 2);
+  assert.equal(summary.counts.retracted, 1);
+  assert.equal(summary.counts['expression-of-concern'], 1);
+  assert.deepEqual(badgeForSummary(summary), {
+    count: 2,
+    color: STATUS_DEFINITIONS.retracted.color,
+    title: '2 references with known integrity signals'
+  });
+});
+
+test('request-start limiter spaces concurrent callers', async () => {
+  let clock = 1000;
+  const sleeps = [];
+  const limiter = createStartRateLimiter(250, () => clock, async milliseconds => {
+    sleeps.push(milliseconds);
+    clock += milliseconds;
+  });
+  const starts = await Promise.all([limiter(), limiter(), limiter(), limiter(), limiter()]);
+  assert.deepEqual(starts, [1000, 1250, 1500, 1750, 2000]);
+  assert.deepEqual(sleeps, [250, 250, 250, 250]);
+});
+
+test('integrity network behavior is explicit opt-in', () => {
+  const scanner = fs.readFileSync(path.join(root, 'content', 'integrity_scanner.js'), 'utf8');
+  const popup = fs.readFileSync(path.join(root, 'popup.js'), 'utf8');
+  assert.match(scanner, /integrityLookupsEnabled:\s*false/);
+  assert.match(scanner, /integrityLookupsEnabled !== true/);
+  assert.match(popup, /integrityLookupsEnabled:\s*false/);
+  assert.match(popup, /integrityLookupsEnabled === true/);
+});
+
+test('all browser targets load the integrity runtime safely', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+  const firefox = JSON.parse(fs.readFileSync(path.join(root, 'platforms', 'firefox', 'manifest.json'), 'utf8'));
+  assert.equal(manifest.background.service_worker, 'background.js');
+  assert.equal(Object.hasOwn(manifest.background, 'type'), false);
+  assert.ok(manifest.content_scripts[0].js.includes('content/integrity_scanner.js'));
+  assert.deepEqual(firefox.background.scripts.slice(0, 2), ['shared/integrity.js', 'background.js']);
+});

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -93,20 +93,31 @@ test('request-start limiter spaces concurrent callers', async () => {
   assert.deepEqual(sleeps, [250, 250, 250, 250]);
 });
 
-test('integrity network behavior is explicit opt-in', () => {
+test('integrity network behavior is explicit opt-in and cancellable', () => {
   const scanner = fs.readFileSync(path.join(root, 'content', 'integrity_scanner.js'), 'utf8');
   const popup = fs.readFileSync(path.join(root, 'popup.js'), 'utf8');
+  const background = fs.readFileSync(path.join(root, 'background.js'), 'utf8');
   assert.match(scanner, /integrityLookupsEnabled:\s*false/);
   assert.match(scanner, /integrityLookupsEnabled !== true/);
   assert.match(popup, /integrityLookupsEnabled:\s*false/);
   assert.match(popup, /integrityLookupsEnabled === true/);
+  assert.match(background, /function cancelIntegrityScan/);
+  assert.match(background, /controller\.abort\(\)/);
+  assert.match(background, /hasIntegrityTransmissionConsent/);
 });
 
 test('all browser targets load the integrity runtime safely', () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
   const firefox = JSON.parse(fs.readFileSync(path.join(root, 'platforms', 'firefox', 'manifest.json'), 'utf8'));
+  const popup = fs.readFileSync(path.join(root, 'popup.js'), 'utf8');
   assert.equal(manifest.background.service_worker, 'background.js');
   assert.equal(Object.hasOwn(manifest.background, 'type'), false);
   assert.ok(manifest.content_scripts[0].js.includes('content/integrity_scanner.js'));
   assert.deepEqual(firefox.background.scripts.slice(0, 2), ['shared/integrity.js', 'background.js']);
+  assert.equal(firefox.browser_specific_settings.gecko.strict_min_version, '140.0');
+  assert.equal(firefox.browser_specific_settings.gecko_android.strict_min_version, '142.0');
+  assert.deepEqual(firefox.browser_specific_settings.gecko.data_collection_permissions.required, ['none']);
+  assert.deepEqual(firefox.browser_specific_settings.gecko.data_collection_permissions.optional, ['websiteContent']);
+  assert.match(popup, /permissions\.request\(\{ data_collection: \['websiteContent'\] \}\)/);
+  assert.match(popup, /permissions\.remove\(\{ data_collection: \['websiteContent'\] \}\)/);
 });

--- a/tests/multi-browser.test.js
+++ b/tests/multi-browser.test.js
@@ -34,18 +34,22 @@ test('one source tree generates isolated browser packages', () => {
       assert.equal(manifest.version_name, '1.2.3-beta.1');
       assert.equal(manifest.homepage_url, 'https://mdpi-filter.pages.dev/');
       assert.deepEqual(manifest.permissions, ['storage']);
+      assert.ok(manifest.content_scripts[0].js.includes('content/integrity_scanner.js'));
     }
 
     assert.equal(chrome.background.service_worker, 'background.js');
     assert.equal(edge.background.service_worker, 'background.js');
-    assert.deepEqual(firefox.background.scripts, ['background.js']);
+    assert.deepEqual(firefox.background.scripts, ['shared/integrity.js', 'background.js']);
     assert.equal(Object.hasOwn(firefox.background, 'service_worker'), false);
     assert.equal(Object.hasOwn(firefox.background, 'type'), false);
     assert.equal(firefox.browser_specific_settings.gecko.id, 'mdpi-filter@mdpi-filter.org');
+    assert.deepEqual(firefox.browser_specific_settings.gecko.data_collection_permissions.optional, ['websiteContent']);
     assert.equal(Object.hasOwn(safari, 'externally_connectable'), false);
 
     for (const target of ['chrome', 'edge', 'firefox', 'safari']) {
       assert.equal(fs.existsSync(path.join(DIST, target, 'background.js')), true);
+      assert.equal(fs.existsSync(path.join(DIST, target, 'shared', 'integrity.js')), true);
+      assert.equal(fs.existsSync(path.join(DIST, target, 'content', 'integrity_scanner.js')), true);
       assert.equal(fs.existsSync(path.join(DIST, target, 'content', 'content_script.js')), true);
       assert.equal(fs.existsSync(path.join(DIST, target, 'scripts')), false);
       assert.equal(fs.existsSync(path.join(DIST, target, 'tests')), false);


### PR DESCRIPTION
## Summary

- adds explainable DOI-level post-publication signals from Crossref/Retraction Watch
- keeps research-integrity lookups off by default
- sends only normalized DOI identifiers after explicit user consent
- limits request starts to four per second and caps each scan at 50 DOIs
- cancels active and queued lookups when disabled, replaced, or navigation begins
- preserves event chronology, provenance, reinstatement, correction, concern, withdrawal, duplicate-publication, and retraction states
- keeps existing MDPI detection and badge behavior when no integrity signal is active
- builds from the canonical source for Chrome, Edge, Firefox, and Safari

## Browser compatibility

- Chrome, Edge, and Safari use the classic Manifest V3 service worker
- Firefox loads the shared classic integrity core before the background script
- Firefox declares optional `websiteContent` data collection and uses Mozilla's built-in permission request/remove flow before any DOI transmission

## Release safety

- version and lockfile are aligned at `0.1.0`
- all store descriptions and privacy links are updated
- Firefox reviewer notes disclose exact transmitted and omitted data
- regression tests cover relationship direction, chronology, request pacing, opt-in defaults, cancellation, and browser-specific consent
- the stable store tag must not be created until `docs/store-release-checklist.md` is completed

## Replaces

Replaces #12, which predated the multi-browser release architecture and did not enforce its stated request pacing, opt-in default, cancellation, or current Firefox data-consent requirements.